### PR TITLE
feat(test): Set up Bun test infrastructure with 99%+ coverage

### DIFF
--- a/.claude/skills/bun-test/PATTERNS.md
+++ b/.claude/skills/bun-test/PATTERNS.md
@@ -1,0 +1,309 @@
+# xfeed Test Patterns
+
+This file contains patterns specific to the xfeed codebase.
+
+## TwitterClient Test Pattern
+
+```typescript
+// @ts-nocheck - Test file with fetch mocking
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+  type Mock,
+} from "bun:test";
+import { TwitterClient } from "./client";
+import { runtimeQueryIds } from "./query-ids";
+
+// Mock implementations
+const mockGetQueryId = mock(() => Promise.resolve(null));
+const mockRefresh = mock(() => Promise.resolve(null));
+
+// Store originals
+const originalFetch = globalThis.fetch;
+const originalNodeEnv = process.env.NODE_ENV;
+
+// Spies
+let getQueryIdSpy: Mock<typeof runtimeQueryIds.getQueryId>;
+let refreshSpy: Mock<typeof runtimeQueryIds.refresh>;
+
+// Mock response helper
+function mockResponse(body: unknown, options: { status?: number; ok?: boolean } = {}) {
+  const status = options.status ?? 200;
+  const ok = options.ok ?? (status >= 200 && status < 300);
+  return {
+    ok,
+    status,
+    text: () => Promise.resolve(typeof body === "string" ? body : JSON.stringify(body)),
+    json: () => Promise.resolve(body),
+  } as Response;
+}
+
+// Valid cookies for tests
+const validCookies = {
+  authToken: "test-auth-token",
+  ct0: "test-ct0",
+  cookieHeader: "auth_token=test-auth-token; ct0=test-ct0",
+  source: "test",
+};
+
+describe("TwitterClient", () => {
+  beforeAll(() => {
+    getQueryIdSpy = spyOn(runtimeQueryIds, "getQueryId").mockImplementation(mockGetQueryId);
+    refreshSpy = spyOn(runtimeQueryIds, "refresh").mockImplementation(mockRefresh);
+  });
+
+  afterAll(() => {
+    getQueryIdSpy.mockRestore();
+    refreshSpy.mockRestore();
+    if (originalNodeEnv !== undefined) {
+      process.env.NODE_ENV = originalNodeEnv;
+    } else {
+      delete process.env.NODE_ENV;
+    }
+  });
+
+  beforeEach(() => {
+    mockGetQueryId.mockReset();
+    mockRefresh.mockReset();
+    process.env.NODE_ENV = "test";
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("example test", async () => {
+    const client = new TwitterClient({ cookies: validCookies });
+    globalThis.fetch = mock(() => Promise.resolve(mockResponse({ data: {} })));
+
+    const result = await client.someMethod();
+    expect(result.success).toBe(true);
+  });
+});
+```
+
+## Runtime Query ID Store Test Pattern
+
+```typescript
+// @ts-nocheck - Test file with fetch mocking
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { createRuntimeQueryIdStore, type RuntimeQueryIdStore } from "./runtime-query-ids";
+
+describe("runtime-query-ids", () => {
+  let store: RuntimeQueryIdStore;
+  let cachePath: string;
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(path.join(tmpdir(), "xfeed-test-"));
+    cachePath = path.join(testDir, "query-ids-cache.json");
+  });
+
+  afterEach(async () => {
+    store?.clearMemory();
+    if (testDir) {
+      await rm(testDir, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+
+  it("reads from cache", async () => {
+    const snapshot = {
+      fetchedAt: new Date().toISOString(),
+      ttlMs: 86400000,
+      ids: { CreateTweet: "abc123" },
+      discovery: { pages: ["https://x.com"], bundles: ["bundle.js"] },
+    };
+    await mkdir(path.dirname(cachePath), { recursive: true });
+    await writeFile(cachePath, JSON.stringify(snapshot));
+
+    store = createRuntimeQueryIdStore({ cachePath });
+    const info = await store.getSnapshotInfo();
+
+    expect(info?.snapshot.ids.CreateTweet).toBe("abc123");
+  });
+
+  it("fetches from network", async () => {
+    const mockFetch = mock((url: string) => {
+      if (url.includes("x.com")) {
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(
+            '<script src="https://abs.twimg.com/responsive-web/client-web/bundle.js"></script>'
+          ),
+        });
+      }
+      if (url.includes("bundle.js")) {
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(
+            'e.exports={queryId:"abc123",operationName:"CreateTweet"}'
+          ),
+        });
+      }
+      return Promise.resolve({ ok: true, text: () => Promise.resolve("") });
+    });
+
+    store = createRuntimeQueryIdStore({
+      cachePath,
+      fetchImpl: mockFetch as typeof fetch,
+    });
+
+    const info = await store.refresh(["CreateTweet"], { force: true });
+    expect(info?.snapshot.ids.CreateTweet).toBe("abc123");
+  });
+});
+```
+
+## Cookie Extraction Test Pattern
+
+```typescript
+// @ts-nocheck - Test file with module mocking
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+// Mutable mock implementation
+let mockImpl = () => Promise.resolve({ cookies: [], warnings: [] });
+
+// Mock BEFORE importing
+mock.module("@steipete/sweet-cookie", () => ({
+  getCookies: () => mockImpl(),
+}));
+
+// NOW import the module
+const { resolveCredentials } = await import("./cookies");
+
+// Helper to set mock cookies
+function setMockCookies(cookies: Array<{ name: string; value: string; domain: string }>) {
+  mockImpl = () => Promise.resolve({ cookies, warnings: [] });
+}
+
+describe("cookies", () => {
+  beforeEach(() => {
+    mockImpl = () => Promise.resolve({ cookies: [], warnings: [] });
+  });
+
+  it("extracts Twitter cookies", async () => {
+    setMockCookies([
+      { name: "auth_token", value: "token123", domain: ".x.com" },
+      { name: "ct0", value: "csrf456", domain: ".x.com" },
+    ]);
+
+    const result = await resolveCredentials();
+    expect(result.authToken).toBe("token123");
+    expect(result.ct0).toBe("csrf456");
+  });
+});
+```
+
+## Multi-Step Mock Pattern (Video Upload)
+
+For tests that require multiple fetch calls in sequence:
+
+```typescript
+it("uploads video with polling", async () => {
+  const client = new TwitterClient({ cookies: validCookies });
+  let callCount = 0;
+
+  globalThis.fetch = mock(() => {
+    callCount++;
+    if (callCount === 1) {
+      // INIT
+      return Promise.resolve(mockResponse({ media_id_string: "video-123" }));
+    }
+    if (callCount === 2) {
+      // APPEND
+      return Promise.resolve(mockResponse({}));
+    }
+    if (callCount === 3) {
+      // FINALIZE - return pending to trigger polling
+      return Promise.resolve(mockResponse({
+        processing_info: { state: "pending", check_after_secs: 0.001 },
+      }));
+    }
+    // STATUS check - return succeeded
+    return Promise.resolve(mockResponse({
+      processing_info: { state: "succeeded" },
+    }));
+  });
+
+  const result = await client.uploadMedia({
+    data: new Uint8Array([1, 2, 3]),
+    mimeType: "video/mp4",
+  });
+
+  expect(result.success).toBe(true);
+  expect(callCount).toBe(4); // INIT + APPEND + FINALIZE + STATUS
+});
+```
+
+## GraphQL Response Patterns
+
+Twitter API responses have nested structures. Use these patterns:
+
+```typescript
+// Tweet response
+const tweetResponse = {
+  data: {
+    tweetResult: {
+      result: {
+        rest_id: "123456",
+        legacy: {
+          full_text: "Hello world!",
+          created_at: "Wed Oct 10 20:19:24 +0000 2018",
+          reply_count: 5,
+          retweet_count: 10,
+          favorite_count: 20,
+          conversation_id_str: "123456",
+        },
+        core: {
+          user_results: {
+            result: {
+              rest_id: "user123",
+              legacy: {
+                screen_name: "testuser",
+                name: "Test User",
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+// Timeline response
+const timelineResponse = {
+  data: {
+    home: {
+      home_timeline_urt: {
+        instructions: [
+          {
+            type: "TimelineAddEntries",
+            entries: [
+              {
+                entryId: "tweet-123",
+                content: {
+                  itemContent: {
+                    tweet_results: {
+                      result: { /* tweet structure */ },
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    },
+  },
+};
+```

--- a/.claude/skills/bun-test/SKILL.md
+++ b/.claude/skills/bun-test/SKILL.md
@@ -1,0 +1,268 @@
+---
+name: bun-test
+description: Write and debug Bun tests with proper mocking, coverage, and isolation. Use when writing tests, debugging test failures, setting up test infrastructure, mocking fetch/modules, or improving test coverage.
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob
+---
+
+# Bun Test Guide
+
+## Quick Start
+
+```typescript
+import { describe, expect, it, mock, spyOn, beforeEach, afterEach, afterAll } from "bun:test";
+
+describe("MyModule", () => {
+  it("does something", () => {
+    expect(1 + 1).toBe(2);
+  });
+});
+```
+
+Run tests:
+```bash
+bun test                    # Run all tests
+bun test --watch            # Watch mode
+bun test --coverage         # With coverage report
+bun test src/api            # Specific directory
+bun test --test-name-pattern "pattern"  # Filter by name
+```
+
+## Mocking Patterns
+
+### Mock Functions
+
+```typescript
+const mockFn = mock(() => "mocked value");
+mockFn();
+expect(mockFn).toHaveBeenCalled();
+expect(mockFn).toHaveBeenCalledTimes(1);
+
+// Reset between tests
+mockFn.mockReset();
+mockFn.mockImplementation(() => "new value");
+```
+
+### Spy on Object Methods
+
+```typescript
+import { myModule } from "./my-module";
+
+let methodSpy: Mock<typeof myModule.method>;
+
+beforeAll(() => {
+  methodSpy = spyOn(myModule, "method").mockImplementation(() => "mocked");
+});
+
+afterAll(() => {
+  methodSpy.mockRestore(); // IMPORTANT: Always restore spies
+});
+```
+
+### Mock fetch (globalThis.fetch)
+
+Bun's `fetch` has extra properties (like `preconnect`) that mocks don't have. Use `// @ts-nocheck` at file top for test files with fetch mocking:
+
+```typescript
+// @ts-nocheck - Test file with fetch mocking
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+const originalFetch = globalThis.fetch;
+
+// Helper for mock responses
+function mockResponse(body: unknown, options: { status?: number; ok?: boolean } = {}) {
+  const status = options.status ?? 200;
+  const ok = options.ok ?? (status >= 200 && status < 300);
+  return {
+    ok,
+    status,
+    text: () => Promise.resolve(typeof body === "string" ? body : JSON.stringify(body)),
+    json: () => Promise.resolve(body),
+  } as Response;
+}
+
+describe("API", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch; // Always restore
+  });
+
+  it("fetches data", async () => {
+    globalThis.fetch = mock(() => Promise.resolve(mockResponse({ data: "test" })));
+
+    const result = await myApi.getData();
+    expect(result).toEqual({ data: "test" });
+  });
+
+  it("handles errors", async () => {
+    globalThis.fetch = mock(() => Promise.reject(new Error("Network error")));
+
+    await expect(myApi.getData()).rejects.toThrow("Network error");
+  });
+});
+```
+
+### Mock Modules (External Dependencies)
+
+Use `mock.module()` BEFORE importing the module under test:
+
+```typescript
+// @ts-nocheck - Test file with module mocking
+import { describe, expect, it, mock } from "bun:test";
+
+// Create mutable mock implementation
+let mockImpl = () => Promise.resolve({ data: "default" });
+
+// Mock the module BEFORE importing
+mock.module("external-package", () => ({
+  someFunction: () => mockImpl(),
+}));
+
+// NOW import the module that uses external-package
+const { myFunction } = await import("./my-module");
+
+// Helper to change mock behavior per test
+function setMockReturn(value: unknown) {
+  mockImpl = () => Promise.resolve(value);
+}
+
+describe("MyModule", () => {
+  it("uses external package", async () => {
+    setMockReturn({ data: "test" });
+    const result = await myFunction();
+    expect(result.data).toBe("test");
+  });
+});
+```
+
+## Test Isolation
+
+### State Sharing Warning
+
+Tests within a file share module-level state. Use setup/teardown hooks carefully:
+
+```typescript
+// Store original values at module level
+const originalEnv = process.env.NODE_ENV;
+const originalFetch = globalThis.fetch;
+
+afterAll(() => {
+  // Restore everything
+  globalThis.fetch = originalFetch;
+  if (originalEnv !== undefined) {
+    process.env.NODE_ENV = originalEnv;
+  } else {
+    delete process.env.NODE_ENV;
+  }
+});
+```
+
+### Temp Directory Isolation
+
+Use `mkdtemp()` per test, not a shared temp directory:
+
+```typescript
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+let testDir: string;
+
+beforeEach(async () => {
+  // Unique temp dir per test - avoids race conditions
+  testDir = await mkdtemp(path.join(tmpdir(), "my-test-"));
+});
+
+afterEach(async () => {
+  if (testDir) {
+    await rm(testDir, { recursive: true, force: true }).catch(() => {});
+  }
+});
+```
+
+## Coverage
+
+```bash
+bun test --coverage              # Generate text report
+bun test --coverage-reporter lcov # For CI/tooling integration
+```
+
+### Coverage Quirks
+
+1. **Closing braces after return** may show uncovered even when executed
+2. **Function declarations** may not count if only body runs
+3. **100% may be impossible** - aim for 99%+ on meaningful code
+
+### Improving Coverage
+
+- Test all branches (if/else, switch cases)
+- Test error paths and edge cases
+- Test with different input types
+- Don't obsess over unreachable code (closing braces, etc.)
+
+## Common Patterns
+
+### Async Tests
+
+```typescript
+it("handles async", async () => {
+  const result = await asyncFunction();
+  expect(result).toBe("expected");
+});
+
+it("expects rejection", async () => {
+  await expect(asyncFunction()).rejects.toThrow("error message");
+});
+```
+
+### Parameterized Tests
+
+```typescript
+const testCases = [
+  { input: 1, expected: 2 },
+  { input: 2, expected: 4 },
+];
+
+for (const { input, expected } of testCases) {
+  it(`doubles ${input} to ${expected}`, () => {
+    expect(double(input)).toBe(expected);
+  });
+}
+```
+
+### Testing Timeouts
+
+```typescript
+it("handles timeout", async () => {
+  // Use small delays for tests
+  const result = await functionWithDelay(1); // 1ms instead of 1000ms
+  expect(result).toBeDefined();
+});
+```
+
+## Checklist for New Test Files
+
+1. Add `// @ts-nocheck` if mocking fetch or complex types
+2. Store original values (fetch, env vars) before modifying
+3. Restore everything in `afterEach` or `afterAll`
+4. Use `mkdtemp()` for temp directories (not shared paths)
+5. Call `mockRestore()` on spies in `afterAll`
+6. Use descriptive test names that explain the scenario
+
+## Debugging Tests
+
+```bash
+bun test --bail                  # Stop on first failure
+bun test --timeout 30000         # Increase timeout (ms)
+bun test --test-name-pattern "specific test"  # Run one test
+```
+
+Add console.log for debugging (remove before committing):
+```typescript
+it("debugging", () => {
+  console.log("Value:", someValue);
+  expect(someValue).toBeDefined();
+});
+```
+
+## Additional Resources
+
+For xfeed-specific patterns (TwitterClient, RuntimeQueryIdStore, cookie mocking, GraphQL responses), see [PATTERNS.md](PATTERNS.md).

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "start": "bun src/index.tsx",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint src && oxfmt --check src",
-    "lint:fix": "oxlint --fix src && oxfmt --write src"
+    "lint:fix": "oxlint --fix src && oxfmt --write src",
+    "test": "bun test",
+    "test:watch": "bun test --watch",
+    "test:coverage": "bun test --coverage"
   },
   "dependencies": {
     "@opentui/core": "^0.1.63",

--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -1,0 +1,2298 @@
+// @ts-nocheck - Test file with complex mocking that conflicts with Bun's strict fetch types
+/**
+ * Unit tests for TwitterClient
+ * Tests all public methods and edge cases for 100% coverage
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+  type Mock,
+} from "bun:test";
+
+import { TwitterClient } from "./client";
+import { runtimeQueryIds } from "./query-ids";
+
+// Mock runtimeQueryIds
+const mockGetQueryId = mock(() => Promise.resolve(null));
+const mockRefresh = mock(() => Promise.resolve(null));
+
+// Store original fetch
+const originalFetch = globalThis.fetch;
+
+// Store original env values for restoration
+const originalNodeEnv = process.env.NODE_ENV;
+const originalDebugArticle = process.env.XFEED_DEBUG_ARTICLE;
+
+// Store spies for cleanup
+let getQueryIdSpy: Mock<typeof runtimeQueryIds.getQueryId>;
+let refreshSpy: Mock<typeof runtimeQueryIds.refresh>;
+
+// Mock response factory
+function mockResponse(
+  body: unknown,
+  options: { status?: number; ok?: boolean } = {}
+) {
+  const status = options.status ?? 200;
+  const ok = options.ok ?? (status >= 200 && status < 300);
+  return {
+    ok,
+    status,
+    text: () =>
+      Promise.resolve(typeof body === "string" ? body : JSON.stringify(body)),
+    json: () => Promise.resolve(body),
+  } as Response;
+}
+
+// Valid cookies for tests
+const validCookies = {
+  authToken: "test-auth-token",
+  ct0: "test-ct0",
+  cookieHeader: "auth_token=test-auth-token; ct0=test-ct0",
+  source: "test",
+};
+
+describe("TwitterClient", () => {
+  beforeAll(() => {
+    // Create spies once for the entire test suite
+    getQueryIdSpy = spyOn(runtimeQueryIds, "getQueryId").mockImplementation(
+      mockGetQueryId
+    );
+    refreshSpy = spyOn(runtimeQueryIds, "refresh").mockImplementation(
+      mockRefresh
+    );
+  });
+
+  afterAll(() => {
+    // Restore original methods
+    getQueryIdSpy.mockRestore();
+    refreshSpy.mockRestore();
+
+    // Restore original env values
+    if (originalNodeEnv !== undefined) {
+      process.env.NODE_ENV = originalNodeEnv;
+    } else {
+      delete process.env.NODE_ENV;
+    }
+    if (originalDebugArticle !== undefined) {
+      process.env.XFEED_DEBUG_ARTICLE = originalDebugArticle;
+    }
+  });
+
+  beforeEach(() => {
+    // Reset mocks
+    mockGetQueryId.mockReset();
+    mockRefresh.mockReset();
+    mockGetQueryId.mockImplementation(() => Promise.resolve(null));
+    mockRefresh.mockImplementation(() => Promise.resolve(null));
+
+    // Set test environment
+    process.env.NODE_ENV = "test";
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    delete process.env.XFEED_DEBUG_ARTICLE;
+  });
+
+  describe("constructor", () => {
+    it("throws if authToken is missing", () => {
+      expect(() => {
+        new TwitterClient({
+          cookies: {
+            authToken: null,
+            ct0: "test",
+            cookieHeader: null,
+            source: null,
+          },
+        });
+      }).toThrow("Both authToken and ct0 cookies are required");
+    });
+
+    it("throws if ct0 is missing", () => {
+      expect(() => {
+        new TwitterClient({
+          cookies: {
+            authToken: "test",
+            ct0: null,
+            cookieHeader: null,
+            source: null,
+          },
+        });
+      }).toThrow("Both authToken and ct0 cookies are required");
+    });
+
+    it("creates client with valid cookies", () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      expect(client).toBeDefined();
+    });
+
+    it("uses provided userAgent", () => {
+      const client = new TwitterClient({
+        cookies: validCookies,
+        userAgent: "CustomAgent/1.0",
+      });
+      expect(client).toBeDefined();
+    });
+
+    it("uses provided timeoutMs", () => {
+      const client = new TwitterClient({
+        cookies: validCookies,
+        timeoutMs: 5000,
+      });
+      expect(client).toBeDefined();
+    });
+
+    it("builds cookieHeader from authToken and ct0 if not provided", () => {
+      const client = new TwitterClient({
+        cookies: {
+          authToken: "abc",
+          ct0: "xyz",
+          cookieHeader: null,
+          source: null,
+        },
+      });
+      expect(client).toBeDefined();
+    });
+  });
+
+  describe("getTweet", () => {
+    it("returns tweet on success", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      const tweetResponse = {
+        data: {
+          tweetResult: {
+            result: {
+              rest_id: "123456",
+              legacy: {
+                full_text: "Hello world!",
+                created_at: "Wed Oct 10 20:19:24 +0000 2018",
+                reply_count: 5,
+                retweet_count: 10,
+                favorite_count: 20,
+                conversation_id_str: "123456",
+              },
+              core: {
+                user_results: {
+                  result: {
+                    rest_id: "user123",
+                    legacy: {
+                      screen_name: "testuser",
+                      name: "Test User",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      globalThis.fetch = mock(() =>
+        Promise.resolve(mockResponse(tweetResponse))
+      );
+
+      const result = await client.getTweet("123456");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.tweet?.id).toBe("123456");
+        expect(result.tweet?.text).toBe("Hello world!");
+        expect(result.tweet?.author.username).toBe("testuser");
+      }
+    });
+
+    it("finds tweet in instructions if not in tweetResult", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      const tweetResponse = {
+        data: {
+          threaded_conversation_with_injections_v2: {
+            instructions: [
+              {
+                entries: [
+                  {
+                    content: {
+                      itemContent: {
+                        tweet_results: {
+                          result: {
+                            rest_id: "123456",
+                            legacy: {
+                              full_text: "Found in instructions!",
+                            },
+                            core: {
+                              user_results: {
+                                result: {
+                                  rest_id: "user123",
+                                  legacy: {
+                                    screen_name: "testuser",
+                                    name: "Test User",
+                                  },
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      };
+
+      globalThis.fetch = mock(() =>
+        Promise.resolve(mockResponse(tweetResponse))
+      );
+
+      const result = await client.getTweet("123456");
+      expect(result.success).toBe(true);
+    });
+
+    it("returns error on HTTP failure", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(mockResponse("Not found", { status: 500, ok: false }))
+      );
+
+      const result = await client.getTweet("123456");
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("HTTP 500");
+      }
+    });
+
+    it("returns error on GraphQL errors", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          mockResponse({
+            errors: [{ message: "Tweet not found" }],
+          })
+        )
+      );
+
+      const result = await client.getTweet("123456");
+      expect(result.success).toBe(false);
+    });
+
+    it("returns error if tweet not found in response", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(mockResponse({ data: {} }))
+      );
+
+      const result = await client.getTweet("123456");
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe("Tweet not found in response");
+      }
+    });
+
+    it("handles fetch exception", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() => Promise.reject(new Error("Network error")));
+
+      const result = await client.getTweet("123456");
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe("Network error");
+      }
+    });
+
+    it("retries with refreshed query IDs on 404", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+
+      // All calls return 404 to test the failure case
+      globalThis.fetch = mock(() =>
+        Promise.resolve(mockResponse("Not found", { status: 404, ok: false }))
+      );
+
+      const result = await client.getTweet("123456");
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("404");
+      }
+    });
+
+    it("extracts article text when present", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      const tweetResponse = {
+        data: {
+          tweetResult: {
+            result: {
+              rest_id: "123456",
+              article: {
+                article_results: {
+                  result: {
+                    title: "Article Title",
+                    plain_text: "This is the article body text.",
+                  },
+                },
+              },
+              core: {
+                user_results: {
+                  result: {
+                    rest_id: "user123",
+                    legacy: { screen_name: "testuser", name: "Test User" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      globalThis.fetch = mock(() =>
+        Promise.resolve(mockResponse(tweetResponse))
+      );
+
+      const result = await client.getTweet("123456");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.tweet?.text).toContain("Article Title");
+        expect(result.tweet?.text).toContain("article body text");
+      }
+    });
+
+    it("extracts note tweet text when present", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      const tweetResponse = {
+        data: {
+          tweetResult: {
+            result: {
+              rest_id: "123456",
+              note_tweet: {
+                note_tweet_results: {
+                  result: {
+                    text: "This is a long note tweet that exceeds 280 characters.",
+                  },
+                },
+              },
+              core: {
+                user_results: {
+                  result: {
+                    rest_id: "user123",
+                    legacy: { screen_name: "testuser", name: "Test User" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      globalThis.fetch = mock(() =>
+        Promise.resolve(mockResponse(tweetResponse))
+      );
+
+      const result = await client.getTweet("123456");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.tweet?.text).toContain("long note tweet");
+      }
+    });
+
+    it("handles article with title only, fetches from UserArticlesTweets", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      let callCount = 0;
+
+      globalThis.fetch = mock(() => {
+        callCount++;
+        if (callCount === 1) {
+          // TweetDetail response with title-only article
+          return Promise.resolve(
+            mockResponse({
+              data: {
+                tweetResult: {
+                  result: {
+                    rest_id: "123456",
+                    article: {
+                      article_results: {
+                        result: { title: "Title Only" },
+                      },
+                      title: "Title Only",
+                    },
+                    core: {
+                      user_results: {
+                        result: {
+                          rest_id: "user123",
+                          legacy: {
+                            screen_name: "testuser",
+                            name: "Test User",
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            })
+          );
+        }
+        // UserArticlesTweets fallback
+        return Promise.resolve(
+          mockResponse({
+            data: {
+              user: {
+                result: {
+                  timeline: {
+                    timeline: {
+                      instructions: [
+                        {
+                          entries: [
+                            {
+                              content: {
+                                itemContent: {
+                                  tweet_results: {
+                                    result: {
+                                      rest_id: "123456",
+                                      article: {
+                                        article_results: {
+                                          result: {
+                                            title: "Title Only",
+                                            plain_text:
+                                              "Article body from fallback.",
+                                          },
+                                        },
+                                      },
+                                    },
+                                  },
+                                },
+                              },
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          })
+        );
+      });
+
+      const result = await client.getTweet("123456");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.tweet?.text).toContain("Article body from fallback");
+      }
+    });
+
+    it("handles debug article logging", async () => {
+      process.env.XFEED_DEBUG_ARTICLE = "1";
+      const client = new TwitterClient({ cookies: validCookies });
+      const tweetResponse = {
+        data: {
+          tweetResult: {
+            result: {
+              rest_id: "123456",
+              article: {
+                article_results: { result: { title: "Debug Article" } },
+              },
+              core: {
+                user_results: {
+                  result: {
+                    rest_id: "user123",
+                    legacy: { screen_name: "testuser", name: "Test User" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      globalThis.fetch = mock(() =>
+        Promise.resolve(mockResponse(tweetResponse))
+      );
+
+      const result = await client.getTweet("123456");
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("tweet", () => {
+    it("posts tweet successfully", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          mockResponse({
+            data: {
+              create_tweet: {
+                tweet_results: {
+                  result: { rest_id: "new-tweet-123" },
+                },
+              },
+            },
+          })
+        )
+      );
+
+      const result = await client.tweet("Hello Twitter!");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.tweetId).toBe("new-tweet-123");
+      }
+    });
+
+    it("posts tweet with media IDs", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          mockResponse({
+            data: {
+              create_tweet: {
+                tweet_results: {
+                  result: { rest_id: "new-tweet-456" },
+                },
+              },
+            },
+          })
+        )
+      );
+
+      const result = await client.tweet("Tweet with media", [
+        "media1",
+        "media2",
+      ]);
+      expect(result.success).toBe(true);
+    });
+
+    it("returns error on HTTP failure", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(mockResponse("Error", { status: 403, ok: false }))
+      );
+
+      const result = await client.tweet("Hello");
+      expect(result.success).toBe(false);
+    });
+
+    it("returns error on GraphQL errors", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          mockResponse({
+            errors: [{ message: "Rate limited", code: 88 }],
+          })
+        )
+      );
+
+      const result = await client.tweet("Hello");
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("Rate limited");
+        expect(result.error).toContain("88");
+      }
+    });
+
+    it("returns error if no tweet ID returned", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          mockResponse({
+            data: { create_tweet: { tweet_results: { result: {} } } },
+          })
+        )
+      );
+
+      const result = await client.tweet("Hello");
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe("Tweet created but no ID returned");
+      }
+    });
+
+    it("retries on 404 and succeeds", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      let callCount = 0;
+
+      globalThis.fetch = mock(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve(
+            mockResponse("Not found", { status: 404, ok: false })
+          );
+        }
+        return Promise.resolve(
+          mockResponse({
+            data: {
+              create_tweet: {
+                tweet_results: {
+                  result: { rest_id: "retry-tweet-123" },
+                },
+              },
+            },
+          })
+        );
+      });
+
+      const result = await client.tweet("Hello");
+      expect(result.success).toBe(true);
+    });
+
+    it("falls back to status update on error 226", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      let callCount = 0;
+
+      globalThis.fetch = mock(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve(
+            mockResponse({
+              errors: [{ message: "Automation detected", code: 226 }],
+            })
+          );
+        }
+        // Status update fallback
+        return Promise.resolve(
+          mockResponse({
+            id_str: "fallback-tweet-123",
+          })
+        );
+      });
+
+      const result = await client.tweet("Hello");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.tweetId).toBe("fallback-tweet-123");
+      }
+    });
+
+    it("handles fetch exception", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.reject(new Error("Connection refused"))
+      );
+
+      const result = await client.tweet("Hello");
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe("Connection refused");
+      }
+    });
+  });
+
+  describe("reply", () => {
+    it("posts reply successfully", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          mockResponse({
+            data: {
+              create_tweet: {
+                tweet_results: {
+                  result: { rest_id: "reply-123" },
+                },
+              },
+            },
+          })
+        )
+      );
+
+      const result = await client.reply(
+        "This is a reply",
+        "original-tweet-123"
+      );
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.tweetId).toBe("reply-123");
+      }
+    });
+
+    it("posts reply with media", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          mockResponse({
+            data: {
+              create_tweet: {
+                tweet_results: {
+                  result: { rest_id: "reply-456" },
+                },
+              },
+            },
+          })
+        )
+      );
+
+      const result = await client.reply("Reply with media", "original-123", [
+        "media1",
+      ]);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("search", () => {
+    it("returns search results on success", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          mockResponse({
+            data: {
+              search_by_raw_query: {
+                search_timeline: {
+                  timeline: {
+                    instructions: [
+                      {
+                        entries: [
+                          {
+                            content: {
+                              itemContent: {
+                                tweet_results: {
+                                  result: {
+                                    rest_id: "search-tweet-1",
+                                    legacy: { full_text: "Search result 1" },
+                                    core: {
+                                      user_results: {
+                                        result: {
+                                          rest_id: "user1",
+                                          legacy: {
+                                            screen_name: "user1",
+                                            name: "User 1",
+                                          },
+                                        },
+                                      },
+                                    },
+                                  },
+                                },
+                              },
+                            },
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          })
+        )
+      );
+
+      const result = await client.search("test query");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.tweets?.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("returns error on HTTP failure", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(mockResponse("Error", { status: 500, ok: false }))
+      );
+
+      const result = await client.search("test");
+      expect(result.success).toBe(false);
+    });
+
+    it("returns error on GraphQL errors", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          mockResponse({
+            errors: [{ message: "Search error" }],
+          })
+        )
+      );
+
+      const result = await client.search("test");
+      expect(result.success).toBe(false);
+    });
+
+    it("retries on 404", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+
+      // All calls return 404 to test failure case
+      globalThis.fetch = mock(() =>
+        Promise.resolve(mockResponse("Not found", { status: 404, ok: false }))
+      );
+
+      const result = await client.search("test");
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("404");
+      }
+    });
+
+    it("handles fetch exception", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.reject(new Error("Network timeout"))
+      );
+
+      const result = await client.search("test");
+      expect(result.success).toBe(false);
+    });
+
+    it("uses custom count parameter", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          mockResponse({
+            data: {
+              search_by_raw_query: {
+                search_timeline: {
+                  timeline: { instructions: [] },
+                },
+              },
+            },
+          })
+        )
+      );
+
+      const result = await client.search("test", 50);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("getCurrentUser", () => {
+    it("returns user from settings endpoint", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          mockResponse({
+            screen_name: "currentuser",
+            name: "Current User",
+            user_id: "12345",
+          })
+        )
+      );
+
+      const result = await client.getCurrentUser();
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.user?.username).toBe("currentuser");
+        expect(result.user?.id).toBe("12345");
+      }
+    });
+
+    it("returns user from verify_credentials endpoint", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      let callCount = 0;
+
+      globalThis.fetch = mock(() => {
+        callCount++;
+        if (callCount <= 2) {
+          return Promise.resolve(
+            mockResponse("Error", { status: 401, ok: false })
+          );
+        }
+        return Promise.resolve(
+          mockResponse({
+            screen_name: "verifieduser",
+            name: "Verified User",
+            user_id_str: "67890",
+          })
+        );
+      });
+
+      const result = await client.getCurrentUser();
+      expect(result.success).toBe(true);
+    });
+
+    it("returns user with nested user object", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          mockResponse({
+            user: {
+              screen_name: "nesteduser",
+              name: "Nested User",
+              id_str: "11111",
+            },
+          })
+        )
+      );
+
+      const result = await client.getCurrentUser();
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.user?.username).toBe("nesteduser");
+      }
+    });
+
+    it("falls back to settings page HTML parsing", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      let callCount = 0;
+
+      globalThis.fetch = mock(() => {
+        callCount++;
+        if (callCount <= 4) {
+          return Promise.resolve(
+            mockResponse("Error", { status: 401, ok: false })
+          );
+        }
+        return Promise.resolve(
+          mockResponse(
+            `<html>some content "screen_name":"htmluser" and "user_id":"99999" with "name":"HTML User"</html>`
+          )
+        );
+      });
+
+      const result = await client.getCurrentUser();
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.user?.username).toBe("htmluser");
+        expect(result.user?.id).toBe("99999");
+      }
+    });
+
+    it("returns error when all endpoints fail", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(mockResponse("Error", { status: 401, ok: false }))
+      );
+
+      const result = await client.getCurrentUser();
+      expect(result.success).toBe(false);
+    });
+
+    it("handles JSON parse error gracefully", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      let callCount = 0;
+
+      globalThis.fetch = mock(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            text: () => Promise.resolve("not json"),
+            json: () => Promise.reject(new Error("Invalid JSON")),
+          } as Response);
+        }
+        return Promise.resolve(
+          mockResponse({
+            screen_name: "fallbackuser",
+            user_id: "12345",
+          })
+        );
+      });
+
+      const result = await client.getCurrentUser();
+      expect(result.success).toBe(true);
+    });
+
+    it("handles fetch exception", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() => Promise.reject(new Error("Network error")));
+
+      const result = await client.getCurrentUser();
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("getReplies", () => {
+    it("returns replies to a tweet", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          mockResponse({
+            data: {
+              threaded_conversation_with_injections_v2: {
+                instructions: [
+                  {
+                    entries: [
+                      {
+                        content: {
+                          itemContent: {
+                            tweet_results: {
+                              result: {
+                                rest_id: "reply-1",
+                                legacy: {
+                                  full_text: "This is a reply",
+                                  in_reply_to_status_id_str: "original-123",
+                                },
+                                core: {
+                                  user_results: {
+                                    result: {
+                                      rest_id: "user1",
+                                      legacy: {
+                                        screen_name: "replier",
+                                        name: "Replier",
+                                      },
+                                    },
+                                  },
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          })
+        )
+      );
+
+      const result = await client.getReplies("original-123");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.tweets?.length).toBe(1);
+      }
+    });
+
+    it("returns error on failure", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(mockResponse("Error", { status: 500, ok: false }))
+      );
+
+      const result = await client.getReplies("123");
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("getThread", () => {
+    it("returns full thread sorted by time", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          mockResponse({
+            data: {
+              threaded_conversation_with_injections_v2: {
+                instructions: [
+                  {
+                    entries: [
+                      {
+                        content: {
+                          itemContent: {
+                            tweet_results: {
+                              result: {
+                                rest_id: "tweet-1",
+                                legacy: {
+                                  full_text: "First tweet",
+                                  created_at: "Wed Oct 10 10:00:00 +0000 2018",
+                                  conversation_id_str: "conv-123",
+                                },
+                                core: {
+                                  user_results: {
+                                    result: {
+                                      rest_id: "user1",
+                                      legacy: {
+                                        screen_name: "user1",
+                                        name: "User 1",
+                                      },
+                                    },
+                                  },
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                      {
+                        content: {
+                          itemContent: {
+                            tweet_results: {
+                              result: {
+                                rest_id: "tweet-2",
+                                legacy: {
+                                  full_text: "Second tweet",
+                                  created_at: "Wed Oct 10 11:00:00 +0000 2018",
+                                  conversation_id_str: "conv-123",
+                                },
+                                core: {
+                                  user_results: {
+                                    result: {
+                                      rest_id: "user1",
+                                      legacy: {
+                                        screen_name: "user1",
+                                        name: "User 1",
+                                      },
+                                    },
+                                  },
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          })
+        )
+      );
+
+      const result = await client.getThread("tweet-1");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.tweets?.length).toBe(2);
+        // Should be sorted by time
+        expect(result.tweets?.[0]?.id).toBe("tweet-1");
+      }
+    });
+
+    it("returns error on failure", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(mockResponse("Error", { status: 500, ok: false }))
+      );
+
+      const result = await client.getThread("123");
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("getBookmarks", () => {
+    it("returns bookmarks on success", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          mockResponse({
+            data: {
+              bookmark_timeline_v2: {
+                timeline: {
+                  instructions: [
+                    {
+                      entries: [
+                        {
+                          content: {
+                            itemContent: {
+                              tweet_results: {
+                                result: {
+                                  rest_id: "bookmark-1",
+                                  legacy: { full_text: "Bookmarked tweet" },
+                                  core: {
+                                    user_results: {
+                                      result: {
+                                        rest_id: "user1",
+                                        legacy: {
+                                          screen_name: "user1",
+                                          name: "User 1",
+                                        },
+                                      },
+                                    },
+                                  },
+                                },
+                              },
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+            },
+          })
+        )
+      );
+
+      const result = await client.getBookmarks();
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.tweets?.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("returns error on HTTP failure", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(mockResponse("Error", { status: 500, ok: false }))
+      );
+
+      const result = await client.getBookmarks();
+      expect(result.success).toBe(false);
+    });
+
+    it("returns error on GraphQL errors", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          mockResponse({
+            errors: [{ message: "Bookmarks error" }],
+          })
+        )
+      );
+
+      const result = await client.getBookmarks();
+      expect(result.success).toBe(false);
+    });
+
+    it("retries on 404", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+
+      // All calls return 404 to test failure case
+      globalThis.fetch = mock(() =>
+        Promise.resolve(mockResponse("Not found", { status: 404, ok: false }))
+      );
+
+      const result = await client.getBookmarks();
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("404");
+      }
+    });
+
+    it("uses custom count parameter", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          mockResponse({
+            data: {
+              bookmark_timeline_v2: {
+                timeline: { instructions: [] },
+              },
+            },
+          })
+        )
+      );
+
+      const result = await client.getBookmarks(50);
+      expect(result.success).toBe(true);
+    });
+
+    it("handles fetch exception", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() => Promise.reject(new Error("Timeout")));
+
+      const result = await client.getBookmarks();
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("getHomeTimeline", () => {
+    it("returns home timeline on success", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          mockResponse({
+            data: {
+              home: {
+                home_timeline_urt: {
+                  instructions: [
+                    {
+                      entries: [
+                        {
+                          content: {
+                            itemContent: {
+                              tweet_results: {
+                                result: {
+                                  rest_id: "home-tweet-1",
+                                  legacy: { full_text: "Home timeline tweet" },
+                                  core: {
+                                    user_results: {
+                                      result: {
+                                        rest_id: "user1",
+                                        legacy: {
+                                          screen_name: "user1",
+                                          name: "User 1",
+                                        },
+                                      },
+                                    },
+                                  },
+                                },
+                              },
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+            },
+          })
+        )
+      );
+
+      const result = await client.getHomeTimeline();
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.tweets?.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("returns error on HTTP failure", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(mockResponse("Error", { status: 500, ok: false }))
+      );
+
+      const result = await client.getHomeTimeline();
+      expect(result.success).toBe(false);
+    });
+
+    it("returns error on GraphQL errors", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          mockResponse({
+            errors: [{ message: "Timeline error" }],
+          })
+        )
+      );
+
+      const result = await client.getHomeTimeline();
+      expect(result.success).toBe(false);
+    });
+
+    it("handles fetch exception", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() => Promise.reject(new Error("Network error")));
+
+      const result = await client.getHomeTimeline();
+      expect(result.success).toBe(false);
+    });
+
+    it("uses custom count parameter", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          mockResponse({
+            data: {
+              home: {
+                home_timeline_urt: { instructions: [] },
+              },
+            },
+          })
+        )
+      );
+
+      const result = await client.getHomeTimeline(50);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("getHomeLatestTimeline", () => {
+    it("returns latest timeline on success", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          mockResponse({
+            data: {
+              home: {
+                home_timeline_urt: {
+                  instructions: [
+                    {
+                      entries: [
+                        {
+                          content: {
+                            itemContent: {
+                              tweet_results: {
+                                result: {
+                                  rest_id: "latest-tweet-1",
+                                  legacy: {
+                                    full_text: "Latest timeline tweet",
+                                  },
+                                  core: {
+                                    user_results: {
+                                      result: {
+                                        rest_id: "user1",
+                                        legacy: {
+                                          screen_name: "user1",
+                                          name: "User 1",
+                                        },
+                                      },
+                                    },
+                                  },
+                                },
+                              },
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+            },
+          })
+        )
+      );
+
+      const result = await client.getHomeLatestTimeline();
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.tweets?.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("returns error on HTTP failure", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(mockResponse("Error", { status: 500, ok: false }))
+      );
+
+      const result = await client.getHomeLatestTimeline();
+      expect(result.success).toBe(false);
+    });
+
+    it("returns error on GraphQL errors", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          mockResponse({
+            errors: [{ message: "Latest timeline error" }],
+          })
+        )
+      );
+
+      const result = await client.getHomeLatestTimeline();
+      expect(result.success).toBe(false);
+    });
+
+    it("handles fetch exception", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.reject(new Error("Connection error"))
+      );
+
+      const result = await client.getHomeLatestTimeline();
+      expect(result.success).toBe(false);
+    });
+
+    it("uses custom count parameter", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          mockResponse({
+            data: {
+              home: {
+                home_timeline_urt: { instructions: [] },
+              },
+            },
+          })
+        )
+      );
+
+      const result = await client.getHomeLatestTimeline(50);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("uploadMedia", () => {
+    it("uploads image successfully", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      let callCount = 0;
+
+      globalThis.fetch = mock(() => {
+        callCount++;
+        if (callCount === 1) {
+          // INIT
+          return Promise.resolve(
+            mockResponse({ media_id_string: "media-123" })
+          );
+        }
+        if (callCount === 2) {
+          // APPEND
+          return Promise.resolve(mockResponse({}));
+        }
+        // FINALIZE
+        return Promise.resolve(
+          mockResponse({ processing_info: { state: "succeeded" } })
+        );
+      });
+
+      const result = await client.uploadMedia({
+        data: new Uint8Array([1, 2, 3]),
+        mimeType: "image/png",
+      });
+      expect(result.success).toBe(true);
+      expect(result.mediaId).toBe("media-123");
+    });
+
+    it("uploads GIF successfully", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(mockResponse({ media_id_string: "gif-123" }))
+      );
+
+      const result = await client.uploadMedia({
+        data: new Uint8Array([1, 2, 3]),
+        mimeType: "image/gif",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("uploads video successfully", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      let callCount = 0;
+
+      globalThis.fetch = mock(() => {
+        callCount++;
+        if (callCount === 1) {
+          // INIT
+          return Promise.resolve(
+            mockResponse({ media_id_string: "video-123" })
+          );
+        }
+        if (callCount === 2) {
+          // APPEND
+          return Promise.resolve(mockResponse({}));
+        }
+        // FINALIZE - return succeeded immediately
+        return Promise.resolve(
+          mockResponse({
+            processing_info: { state: "succeeded" },
+          })
+        );
+      });
+
+      const result = await client.uploadMedia({
+        data: new Uint8Array([1, 2, 3]),
+        mimeType: "video/mp4",
+      });
+      expect(result.success).toBe(true);
+      expect(result.mediaId).toBe("video-123");
+    });
+
+    it("polls for video processing when state is pending", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      let callCount = 0;
+
+      globalThis.fetch = mock(() => {
+        callCount++;
+        if (callCount === 1) {
+          // INIT
+          return Promise.resolve(
+            mockResponse({ media_id_string: "video-poll-123" })
+          );
+        }
+        if (callCount === 2) {
+          // APPEND
+          return Promise.resolve(mockResponse({}));
+        }
+        if (callCount === 3) {
+          // FINALIZE - return pending to trigger polling
+          return Promise.resolve(
+            mockResponse({
+              processing_info: { state: "pending", check_after_secs: 0.001 },
+            })
+          );
+        }
+        // STATUS check - return succeeded
+        return Promise.resolve(
+          mockResponse({
+            processing_info: { state: "succeeded" },
+          })
+        );
+      });
+
+      const result = await client.uploadMedia({
+        data: new Uint8Array([1, 2, 3]),
+        mimeType: "video/mp4",
+      });
+      expect(result.success).toBe(true);
+      expect(result.mediaId).toBe("video-poll-123");
+      // Verify polling happened (INIT + APPEND + FINALIZE + STATUS = 4 calls)
+      expect(callCount).toBe(4);
+    });
+
+    it("returns error for unsupported media type", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+
+      const result = await client.uploadMedia({
+        data: new Uint8Array([1, 2, 3]),
+        mimeType: "application/pdf",
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Unsupported media type");
+    });
+
+    it("returns error on INIT failure", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(mockResponse("Error", { status: 400, ok: false }))
+      );
+
+      const result = await client.uploadMedia({
+        data: new Uint8Array([1, 2, 3]),
+        mimeType: "image/png",
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("HTTP 400");
+    });
+
+    it("returns error if INIT returns no media_id", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() => Promise.resolve(mockResponse({})));
+
+      const result = await client.uploadMedia({
+        data: new Uint8Array([1, 2, 3]),
+        mimeType: "image/png",
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("did not return media_id");
+    });
+
+    it("returns error on APPEND failure", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      let callCount = 0;
+
+      globalThis.fetch = mock(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve(
+            mockResponse({ media_id_string: "media-123" })
+          );
+        }
+        return Promise.resolve(
+          mockResponse("Error", { status: 400, ok: false })
+        );
+      });
+
+      const result = await client.uploadMedia({
+        data: new Uint8Array([1, 2, 3]),
+        mimeType: "image/png",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("returns error on FINALIZE failure", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      let callCount = 0;
+
+      globalThis.fetch = mock(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve(
+            mockResponse({ media_id_string: "media-123" })
+          );
+        }
+        if (callCount === 2) {
+          return Promise.resolve(mockResponse({}));
+        }
+        return Promise.resolve(
+          mockResponse("Error", { status: 400, ok: false })
+        );
+      });
+
+      const result = await client.uploadMedia({
+        data: new Uint8Array([1, 2, 3]),
+        mimeType: "image/png",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("handles processing failure state", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      let callCount = 0;
+
+      globalThis.fetch = mock(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve(
+            mockResponse({ media_id_string: "media-123" })
+          );
+        }
+        if (callCount === 2) {
+          return Promise.resolve(mockResponse({}));
+        }
+        return Promise.resolve(
+          mockResponse({
+            processing_info: {
+              state: "failed",
+              error: { message: "Processing failed" },
+            },
+          })
+        );
+      });
+
+      const result = await client.uploadMedia({
+        data: new Uint8Array([1, 2, 3]),
+        mimeType: "image/png",
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Processing failed");
+    });
+
+    it("adds alt text for images", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      let callCount = 0;
+
+      globalThis.fetch = mock(() => {
+        callCount++;
+        if (callCount <= 3) {
+          return Promise.resolve(
+            mockResponse({ media_id_string: "media-123" })
+          );
+        }
+        // Alt text request
+        return Promise.resolve(mockResponse({}));
+      });
+
+      const result = await client.uploadMedia({
+        data: new Uint8Array([1, 2, 3]),
+        mimeType: "image/png",
+        alt: "Image description",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("returns error on alt text failure", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      let callCount = 0;
+
+      globalThis.fetch = mock(() => {
+        callCount++;
+        if (callCount <= 3) {
+          return Promise.resolve(
+            mockResponse({ media_id_string: "media-123" })
+          );
+        }
+        return Promise.resolve(
+          mockResponse("Error", { status: 400, ok: false })
+        );
+      });
+
+      const result = await client.uploadMedia({
+        data: new Uint8Array([1, 2, 3]),
+        mimeType: "image/png",
+        alt: "Image description",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("handles fetch exception", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() => Promise.reject(new Error("Upload failed")));
+
+      const result = await client.uploadMedia({
+        data: new Uint8Array([1, 2, 3]),
+        mimeType: "image/png",
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Upload failed");
+    });
+
+    it("handles chunked upload for large files", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      const largeData = new Uint8Array(10 * 1024 * 1024); // 10MB
+      let appendCount = 0;
+
+      globalThis.fetch = mock((url: string, init?: RequestInit) => {
+        const body = init?.body;
+        if (body instanceof URLSearchParams) {
+          const command = body.get("command");
+          if (command === "INIT") {
+            return Promise.resolve(
+              mockResponse({ media_id_string: "large-media-123" })
+            );
+          }
+          if (command === "FINALIZE") {
+            return Promise.resolve(mockResponse({}));
+          }
+        }
+        if (body instanceof FormData) {
+          appendCount++;
+          return Promise.resolve(mockResponse({}));
+        }
+        return Promise.resolve(mockResponse({}));
+      });
+
+      const result = await client.uploadMedia({
+        data: largeData,
+        mimeType: "video/mp4",
+      });
+      expect(result.success).toBe(true);
+      expect(appendCount).toBe(2); // 10MB / 5MB = 2 chunks
+    });
+
+    it("uses media_id when media_id_string is missing", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      let callCount = 0;
+
+      globalThis.fetch = mock(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve(mockResponse({ media_id: 12345 }));
+        }
+        return Promise.resolve(mockResponse({}));
+      });
+
+      const result = await client.uploadMedia({
+        data: new Uint8Array([1, 2, 3]),
+        mimeType: "image/png",
+      });
+      expect(result.success).toBe(true);
+      expect(result.mediaId).toBe("12345");
+    });
+  });
+
+  describe("timeout handling", () => {
+    it("respects timeout setting", async () => {
+      const client = new TwitterClient({
+        cookies: validCookies,
+        timeoutMs: 100,
+      });
+
+      globalThis.fetch = mock(
+        () =>
+          new Promise((resolve) => {
+            setTimeout(() => resolve(mockResponse({ data: {} })), 200);
+          })
+      );
+
+      const result = await client.getTweet("123");
+      // Should abort before completion
+      expect(result.success).toBe(false);
+    });
+
+    it("does not use timeout when set to 0", async () => {
+      const client = new TwitterClient({
+        cookies: validCookies,
+        timeoutMs: 0,
+      });
+
+      globalThis.fetch = mock(() =>
+        Promise.resolve(mockResponse({ data: {} }))
+      );
+
+      const result = await client.getTweet("123");
+      expect(result.success).toBe(false); // No tweet in response
+    });
+  });
+
+  describe("tweet result parsing edge cases", () => {
+    it("handles tweet with core.screen_name instead of legacy.screen_name", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          mockResponse({
+            data: {
+              tweetResult: {
+                result: {
+                  rest_id: "123456",
+                  legacy: { full_text: "Tweet text" },
+                  core: {
+                    user_results: {
+                      result: {
+                        rest_id: "user123",
+                        core: {
+                          screen_name: "coreuser",
+                          name: "Core User",
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          })
+        )
+      );
+
+      const result = await client.getTweet("123456");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.tweet?.author.username).toBe("coreuser");
+      }
+    });
+
+    it("handles tweet with missing text fields gracefully", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          mockResponse({
+            data: {
+              tweetResult: {
+                result: {
+                  rest_id: "123456",
+                  core: {
+                    user_results: {
+                      result: {
+                        rest_id: "user123",
+                        legacy: { screen_name: "testuser" },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          })
+        )
+      );
+
+      const result = await client.getTweet("123456");
+      // Should fail because no text was found
+      expect(result.success).toBe(false);
+    });
+
+    it("handles items array in instructions via getThread", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          mockResponse({
+            data: {
+              threaded_conversation_with_injections_v2: {
+                instructions: [
+                  {
+                    entries: [
+                      {
+                        content: {
+                          items: [
+                            {
+                              item: {
+                                itemContent: {
+                                  tweet_results: {
+                                    result: {
+                                      rest_id: "nested-tweet-1",
+                                      legacy: {
+                                        full_text: "Nested tweet",
+                                        conversation_id_str: "conv-123",
+                                      },
+                                      core: {
+                                        user_results: {
+                                          result: {
+                                            rest_id: "user1",
+                                            legacy: {
+                                              screen_name: "user1",
+                                              name: "User",
+                                            },
+                                          },
+                                        },
+                                      },
+                                    },
+                                  },
+                                },
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          })
+        )
+      );
+
+      // getThread uses parseTweetsFromInstructions which checks items array
+      const result = await client.getThread("nested-tweet-1");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.tweets?.length).toBe(1);
+        expect(result.tweets?.[0]?.id).toBe("nested-tweet-1");
+      }
+    });
+
+    it("deduplicates tweets by ID", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          mockResponse({
+            data: {
+              search_by_raw_query: {
+                search_timeline: {
+                  timeline: {
+                    instructions: [
+                      {
+                        entries: [
+                          {
+                            content: {
+                              itemContent: {
+                                tweet_results: {
+                                  result: {
+                                    rest_id: "same-id",
+                                    legacy: { full_text: "First occurrence" },
+                                    core: {
+                                      user_results: {
+                                        result: {
+                                          rest_id: "user1",
+                                          legacy: {
+                                            screen_name: "user1",
+                                            name: "User",
+                                          },
+                                        },
+                                      },
+                                    },
+                                  },
+                                },
+                              },
+                            },
+                          },
+                          {
+                            content: {
+                              itemContent: {
+                                tweet_results: {
+                                  result: {
+                                    rest_id: "same-id",
+                                    legacy: { full_text: "Duplicate" },
+                                    core: {
+                                      user_results: {
+                                        result: {
+                                          rest_id: "user1",
+                                          legacy: {
+                                            screen_name: "user1",
+                                            name: "User",
+                                          },
+                                        },
+                                      },
+                                    },
+                                  },
+                                },
+                              },
+                            },
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          })
+        )
+      );
+
+      const result = await client.search("test");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.tweets?.length).toBe(1);
+      }
+    });
+  });
+
+  describe("article text extraction edge cases", () => {
+    it("extracts text from richtext field", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          mockResponse({
+            data: {
+              tweetResult: {
+                result: {
+                  rest_id: "123456",
+                  note_tweet: {
+                    note_tweet_results: {
+                      result: {
+                        richtext: { text: "Richtext content" },
+                      },
+                    },
+                  },
+                  core: {
+                    user_results: {
+                      result: {
+                        rest_id: "user123",
+                        legacy: { screen_name: "testuser", name: "Test" },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          })
+        )
+      );
+
+      const result = await client.getTweet("123456");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.tweet?.text).toBe("Richtext content");
+      }
+    });
+
+    it("extracts text from content.richtext field", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          mockResponse({
+            data: {
+              tweetResult: {
+                result: {
+                  rest_id: "123456",
+                  note_tweet: {
+                    note_tweet_results: {
+                      result: {
+                        content: {
+                          richtext: { text: "Content richtext" },
+                        },
+                      },
+                    },
+                  },
+                  core: {
+                    user_results: {
+                      result: {
+                        rest_id: "user123",
+                        legacy: { screen_name: "testuser", name: "Test" },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          })
+        )
+      );
+
+      const result = await client.getTweet("123456");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.tweet?.text).toBe("Content richtext");
+      }
+    });
+
+    it("collects text fields from nested article structure", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          mockResponse({
+            data: {
+              tweetResult: {
+                result: {
+                  rest_id: "123456",
+                  article: {
+                    article_results: {
+                      result: {
+                        title: "Same Title",
+                        sections: [
+                          {
+                            items: [{ text: "Section item text" }],
+                          },
+                        ],
+                      },
+                    },
+                    title: "Same Title",
+                  },
+                  core: {
+                    user_results: {
+                      result: {
+                        rest_id: "user123",
+                        legacy: { screen_name: "testuser", name: "Test" },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          })
+        )
+      );
+
+      const result = await client.getTweet("123456");
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("status update fallback", () => {
+    it("handles fallback with reply", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      let callCount = 0;
+
+      globalThis.fetch = mock(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve(
+            mockResponse({
+              errors: [{ message: "Automation", code: 226 }],
+            })
+          );
+        }
+        return Promise.resolve(mockResponse({ id_str: "fallback-reply-123" }));
+      });
+
+      const result = await client.reply("Reply text", "original-123");
+      expect(result.success).toBe(true);
+    });
+
+    it("returns combined error when fallback also fails", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      let callCount = 0;
+
+      globalThis.fetch = mock(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve(
+            mockResponse({
+              errors: [{ message: "Automation", code: 226 }],
+            })
+          );
+        }
+        return Promise.resolve(
+          mockResponse({
+            errors: [{ message: "Rate limited" }],
+          })
+        );
+      });
+
+      const result = await client.tweet("Hello");
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("Automation");
+        expect(result.error).toContain("fallback");
+      }
+    });
+
+    it("handles fallback HTTP error", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      let callCount = 0;
+
+      globalThis.fetch = mock(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve(
+            mockResponse({
+              errors: [{ message: "Automation", code: 226 }],
+            })
+          );
+        }
+        return Promise.resolve(
+          mockResponse("Error", { status: 403, ok: false })
+        );
+      });
+
+      const result = await client.tweet("Hello");
+      expect(result.success).toBe(false);
+    });
+
+    it("handles fallback with media IDs", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      let callCount = 0;
+
+      globalThis.fetch = mock(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve(
+            mockResponse({
+              errors: [{ message: "Automation", code: 226 }],
+            })
+          );
+        }
+        return Promise.resolve(mockResponse({ id: 123456789 }));
+      });
+
+      const result = await client.tweet("With media", ["media1", "media2"]);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.tweetId).toBe("123456789");
+      }
+    });
+
+    it("returns null from status update parsing if no text", async () => {
+      const client = new TwitterClient({ cookies: validCookies });
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          mockResponse({
+            errors: [{ message: "Automation", code: 226 }],
+          })
+        )
+      );
+
+      // Internally the fallback won't work if tweet_text is not a string
+      // but we can't easily trigger this path from public API
+      const result = await client.tweet("Valid text");
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/src/api/query-ids.test.ts
+++ b/src/api/query-ids.test.ts
@@ -1,0 +1,118 @@
+// @ts-nocheck - Test file
+/**
+ * Unit tests for query-ids.ts
+ * Tests query ID constants and exports
+ */
+
+import { describe, expect, it } from "bun:test";
+
+import {
+  FALLBACK_QUERY_IDS,
+  QUERY_IDS,
+  TARGET_QUERY_ID_OPERATIONS,
+  createRuntimeQueryIdStore,
+  runtimeQueryIds,
+} from "./query-ids";
+
+describe("query-ids", () => {
+  describe("FALLBACK_QUERY_IDS", () => {
+    it("contains all required operation names", () => {
+      expect(FALLBACK_QUERY_IDS.CreateTweet).toBeDefined();
+      expect(FALLBACK_QUERY_IDS.CreateRetweet).toBeDefined();
+      expect(FALLBACK_QUERY_IDS.FavoriteTweet).toBeDefined();
+      expect(FALLBACK_QUERY_IDS.TweetDetail).toBeDefined();
+      expect(FALLBACK_QUERY_IDS.SearchTimeline).toBeDefined();
+      expect(FALLBACK_QUERY_IDS.UserArticlesTweets).toBeDefined();
+      expect(FALLBACK_QUERY_IDS.Bookmarks).toBeDefined();
+      expect(FALLBACK_QUERY_IDS.HomeTimeline).toBeDefined();
+      expect(FALLBACK_QUERY_IDS.HomeLatestTimeline).toBeDefined();
+    });
+
+    it("has valid query ID format for all operations", () => {
+      const queryIdRegex = /^[a-zA-Z0-9_-]+$/;
+      for (const [_name, id] of Object.entries(FALLBACK_QUERY_IDS)) {
+        expect(queryIdRegex.test(id)).toBe(true);
+      }
+    });
+  });
+
+  describe("TARGET_QUERY_ID_OPERATIONS", () => {
+    it("contains all fallback operation names", () => {
+      const fallbackKeys = Object.keys(FALLBACK_QUERY_IDS);
+      expect(TARGET_QUERY_ID_OPERATIONS.length).toBe(fallbackKeys.length);
+
+      for (const key of fallbackKeys) {
+        expect(TARGET_QUERY_ID_OPERATIONS).toContain(key);
+      }
+    });
+
+    it("is an array of strings", () => {
+      expect(Array.isArray(TARGET_QUERY_ID_OPERATIONS)).toBe(true);
+      for (const op of TARGET_QUERY_ID_OPERATIONS) {
+        expect(typeof op).toBe("string");
+      }
+    });
+  });
+
+  describe("QUERY_IDS", () => {
+    it("contains all fallback query IDs", () => {
+      for (const [name, _id] of Object.entries(FALLBACK_QUERY_IDS)) {
+        expect(QUERY_IDS[name as keyof typeof QUERY_IDS]).toBeDefined();
+      }
+    });
+
+    it("merges JSON file IDs with fallbacks", () => {
+      // The JSON file may override some fallbacks
+      // Just verify the structure is correct
+      expect(QUERY_IDS.CreateTweet).toBeDefined();
+      expect(typeof QUERY_IDS.CreateTweet).toBe("string");
+    });
+
+    it("has all operation names from OperationName type", () => {
+      const expectedOps = [
+        "CreateTweet",
+        "CreateRetweet",
+        "FavoriteTweet",
+        "TweetDetail",
+        "SearchTimeline",
+        "UserArticlesTweets",
+        "Bookmarks",
+        "HomeTimeline",
+        "HomeLatestTimeline",
+      ];
+
+      for (const op of expectedOps) {
+        expect(QUERY_IDS[op as keyof typeof QUERY_IDS]).toBeDefined();
+      }
+    });
+  });
+
+  describe("runtimeQueryIds", () => {
+    it("exports singleton store", () => {
+      expect(runtimeQueryIds).toBeDefined();
+      expect(typeof runtimeQueryIds.getQueryId).toBe("function");
+      expect(typeof runtimeQueryIds.refresh).toBe("function");
+      expect(typeof runtimeQueryIds.getSnapshotInfo).toBe("function");
+      expect(typeof runtimeQueryIds.clearMemory).toBe("function");
+    });
+
+    it("has default TTL", () => {
+      expect(runtimeQueryIds.ttlMs).toBe(24 * 60 * 60 * 1000);
+    });
+
+    it("has cache path set", () => {
+      expect(runtimeQueryIds.cachePath).toBeDefined();
+      expect(typeof runtimeQueryIds.cachePath).toBe("string");
+    });
+  });
+
+  describe("createRuntimeQueryIdStore", () => {
+    it("is exported and callable", () => {
+      expect(typeof createRuntimeQueryIdStore).toBe("function");
+
+      const store = createRuntimeQueryIdStore({ ttlMs: 1000 });
+      expect(store).toBeDefined();
+      expect(store.ttlMs).toBe(1000);
+    });
+  });
+});

--- a/src/api/runtime-query-ids.test.ts
+++ b/src/api/runtime-query-ids.test.ts
@@ -1,0 +1,926 @@
+// @ts-nocheck - Test file with complex mocking that conflicts with Bun's strict fetch types
+/**
+ * Unit tests for runtime-query-ids
+ * Tests query ID discovery, caching, and refresh functionality
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  createRuntimeQueryIdStore,
+  type RuntimeQueryIdStore,
+} from "./runtime-query-ids";
+
+describe("runtime-query-ids", () => {
+  let store: RuntimeQueryIdStore;
+  let cachePath: string;
+  let testDir: string;
+
+  beforeEach(async () => {
+    // Create a unique temp directory per test to avoid race conditions
+    testDir = await mkdtemp(path.join(tmpdir(), "xfeed-test-"));
+    cachePath = path.join(testDir, "query-ids-cache.json");
+  });
+
+  afterEach(async () => {
+    store?.clearMemory();
+    if (testDir) {
+      try {
+        await rm(testDir, { recursive: true, force: true });
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  });
+
+  describe("createRuntimeQueryIdStore", () => {
+    it("creates store with default options", () => {
+      store = createRuntimeQueryIdStore();
+      expect(store.cachePath).toBeDefined();
+      expect(store.ttlMs).toBe(24 * 60 * 60 * 1000);
+    });
+
+    it("creates store with custom cache path", () => {
+      store = createRuntimeQueryIdStore({ cachePath });
+      expect(store.cachePath).toBe(cachePath);
+    });
+
+    it("creates store with custom TTL", () => {
+      store = createRuntimeQueryIdStore({ cachePath, ttlMs: 1000 });
+      expect(store.ttlMs).toBe(1000);
+    });
+
+    it("resolves relative cache path to absolute", () => {
+      store = createRuntimeQueryIdStore({ cachePath: "./test-cache.json" });
+      expect(path.isAbsolute(store.cachePath)).toBe(true);
+    });
+  });
+
+  describe("getSnapshotInfo", () => {
+    it("returns null when no cache exists", async () => {
+      store = createRuntimeQueryIdStore({ cachePath });
+      const info = await store.getSnapshotInfo();
+      expect(info).toBeNull();
+    });
+
+    it("returns snapshot info when cache exists", async () => {
+      const snapshot = {
+        fetchedAt: new Date().toISOString(),
+        ttlMs: 86400000,
+        ids: { CreateTweet: "abc123" },
+        discovery: { pages: ["https://x.com"], bundles: ["bundle.js"] },
+      };
+      await mkdir(path.dirname(cachePath), { recursive: true });
+      await writeFile(cachePath, JSON.stringify(snapshot));
+
+      store = createRuntimeQueryIdStore({ cachePath });
+      const info = await store.getSnapshotInfo();
+
+      expect(info).not.toBeNull();
+      expect(info?.snapshot.ids.CreateTweet).toBe("abc123");
+      expect(info?.isFresh).toBe(true);
+    });
+
+    it("marks snapshot as stale when TTL exceeded", async () => {
+      const oldDate = new Date(Date.now() - 48 * 60 * 60 * 1000); // 48 hours ago
+      const snapshot = {
+        fetchedAt: oldDate.toISOString(),
+        ttlMs: 86400000, // 24 hours
+        ids: { CreateTweet: "abc123" },
+        discovery: { pages: [], bundles: [] },
+      };
+      await mkdir(path.dirname(cachePath), { recursive: true });
+      await writeFile(cachePath, JSON.stringify(snapshot));
+
+      store = createRuntimeQueryIdStore({ cachePath });
+      const info = await store.getSnapshotInfo();
+
+      expect(info).not.toBeNull();
+      expect(info?.isFresh).toBe(false);
+      expect(info?.ageMs).toBeGreaterThan(86400000);
+    });
+
+    it("uses snapshot TTL when different from store TTL", async () => {
+      const snapshot = {
+        fetchedAt: new Date().toISOString(),
+        ttlMs: 1000, // Very short TTL
+        ids: { CreateTweet: "abc123" },
+        discovery: { pages: [], bundles: [] },
+      };
+      await mkdir(path.dirname(cachePath), { recursive: true });
+      await writeFile(cachePath, JSON.stringify(snapshot));
+
+      store = createRuntimeQueryIdStore({ cachePath, ttlMs: 86400000 });
+      const info = await store.getSnapshotInfo();
+
+      expect(info?.snapshot.ttlMs).toBe(1000);
+    });
+
+    it("caches snapshot in memory after first load", async () => {
+      const snapshot = {
+        fetchedAt: new Date().toISOString(),
+        ttlMs: 86400000,
+        ids: { CreateTweet: "first" },
+        discovery: { pages: [], bundles: [] },
+      };
+      await mkdir(path.dirname(cachePath), { recursive: true });
+      await writeFile(cachePath, JSON.stringify(snapshot));
+
+      store = createRuntimeQueryIdStore({ cachePath });
+
+      // First call
+      const info1 = await store.getSnapshotInfo();
+      expect(info1?.snapshot.ids.CreateTweet).toBe("first");
+
+      // Modify file (should not affect cached result)
+      snapshot.ids.CreateTweet = "second";
+      await writeFile(cachePath, JSON.stringify(snapshot));
+
+      // Second call should return cached
+      const info2 = await store.getSnapshotInfo();
+      expect(info2?.snapshot.ids.CreateTweet).toBe("first");
+    });
+
+    it("handles invalid JSON in cache file", async () => {
+      await mkdir(path.dirname(cachePath), { recursive: true });
+      await writeFile(cachePath, "not valid json");
+
+      store = createRuntimeQueryIdStore({ cachePath });
+      const info = await store.getSnapshotInfo();
+
+      expect(info).toBeNull();
+    });
+
+    it("handles invalid snapshot structure", async () => {
+      await mkdir(path.dirname(cachePath), { recursive: true });
+      await writeFile(cachePath, JSON.stringify({ invalid: "structure" }));
+
+      store = createRuntimeQueryIdStore({ cachePath });
+      const info = await store.getSnapshotInfo();
+
+      expect(info).toBeNull();
+    });
+
+    it("handles non-object JSON in cache file (number)", async () => {
+      await mkdir(path.dirname(cachePath), { recursive: true });
+      // Write a valid JSON number - parseSnapshot should return null for non-object
+      await writeFile(cachePath, "12345");
+
+      store = createRuntimeQueryIdStore({ cachePath });
+      const info = await store.getSnapshotInfo();
+
+      expect(info).toBeNull();
+    });
+
+    it("handles non-object JSON in cache file (string)", async () => {
+      await mkdir(path.dirname(cachePath), { recursive: true });
+      // Write a valid JSON string - parseSnapshot should return null for non-object
+      await writeFile(cachePath, '"just a string"');
+
+      store = createRuntimeQueryIdStore({ cachePath });
+      const info = await store.getSnapshotInfo();
+
+      expect(info).toBeNull();
+    });
+
+    it("handles missing discovery.pages", async () => {
+      const invalidSnapshot = {
+        fetchedAt: new Date().toISOString(),
+        ttlMs: 86400000,
+        ids: { CreateTweet: "abc123" },
+        discovery: { bundles: [] },
+      };
+      await mkdir(path.dirname(cachePath), { recursive: true });
+      await writeFile(cachePath, JSON.stringify(invalidSnapshot));
+
+      store = createRuntimeQueryIdStore({ cachePath });
+      const info = await store.getSnapshotInfo();
+
+      expect(info).toBeNull();
+    });
+
+    it("handles missing discovery.bundles", async () => {
+      const invalidSnapshot = {
+        fetchedAt: new Date().toISOString(),
+        ttlMs: 86400000,
+        ids: { CreateTweet: "abc123" },
+        discovery: { pages: [] },
+      };
+      await mkdir(path.dirname(cachePath), { recursive: true });
+      await writeFile(cachePath, JSON.stringify(invalidSnapshot));
+
+      store = createRuntimeQueryIdStore({ cachePath });
+      const info = await store.getSnapshotInfo();
+
+      expect(info).toBeNull();
+    });
+
+    it("normalizes empty string IDs", async () => {
+      const snapshot = {
+        fetchedAt: new Date().toISOString(),
+        ttlMs: 86400000,
+        ids: { CreateTweet: "   ", ValidId: "abc123" },
+        discovery: { pages: [], bundles: [] },
+      };
+      await mkdir(path.dirname(cachePath), { recursive: true });
+      await writeFile(cachePath, JSON.stringify(snapshot));
+
+      store = createRuntimeQueryIdStore({ cachePath });
+      const info = await store.getSnapshotInfo();
+
+      expect(info?.snapshot.ids.CreateTweet).toBeUndefined();
+      expect(info?.snapshot.ids.ValidId).toBe("abc123");
+    });
+
+    it("handles invalid fetchedAt date", async () => {
+      const snapshot = {
+        fetchedAt: "invalid-date",
+        ttlMs: 86400000,
+        ids: { CreateTweet: "abc123" },
+        discovery: { pages: [], bundles: [] },
+      };
+      await mkdir(path.dirname(cachePath), { recursive: true });
+      await writeFile(cachePath, JSON.stringify(snapshot));
+
+      store = createRuntimeQueryIdStore({ cachePath });
+      const info = await store.getSnapshotInfo();
+
+      expect(info).not.toBeNull();
+      expect(info?.ageMs).toBe(Number.POSITIVE_INFINITY);
+      expect(info?.isFresh).toBe(false);
+    });
+  });
+
+  describe("getQueryId", () => {
+    it("returns null when no cache exists", async () => {
+      store = createRuntimeQueryIdStore({ cachePath });
+      const id = await store.getQueryId("CreateTweet");
+      expect(id).toBeNull();
+    });
+
+    it("returns query ID from cache", async () => {
+      const snapshot = {
+        fetchedAt: new Date().toISOString(),
+        ttlMs: 86400000,
+        ids: { CreateTweet: "abc123", TweetDetail: "def456" },
+        discovery: { pages: [], bundles: [] },
+      };
+      await mkdir(path.dirname(cachePath), { recursive: true });
+      await writeFile(cachePath, JSON.stringify(snapshot));
+
+      store = createRuntimeQueryIdStore({ cachePath });
+
+      expect(await store.getQueryId("CreateTweet")).toBe("abc123");
+      expect(await store.getQueryId("TweetDetail")).toBe("def456");
+      expect(await store.getQueryId("NonExistent")).toBeNull();
+    });
+  });
+
+  describe("refresh", () => {
+    it("returns current snapshot if fresh and not forced", async () => {
+      const snapshot = {
+        fetchedAt: new Date().toISOString(),
+        ttlMs: 86400000,
+        ids: { CreateTweet: "existing123" },
+        discovery: { pages: [], bundles: [] },
+      };
+      await mkdir(path.dirname(cachePath), { recursive: true });
+      await writeFile(cachePath, JSON.stringify(snapshot));
+
+      store = createRuntimeQueryIdStore({ cachePath });
+      const info = await store.refresh(["CreateTweet"]);
+
+      expect(info?.snapshot.ids.CreateTweet).toBe("existing123");
+    });
+
+    it("fetches new IDs when forced", async () => {
+      const mockFetch = mock((url: string) => {
+        if (url.includes("x.com")) {
+          return Promise.resolve({
+            ok: true,
+            text: () =>
+              Promise.resolve(
+                '<script src="https://abs.twimg.com/responsive-web/client-web/bundle.abc123.js"></script>'
+              ),
+          });
+        }
+        if (url.includes("abs.twimg.com")) {
+          return Promise.resolve({
+            ok: true,
+            text: () =>
+              Promise.resolve(
+                'e.exports={queryId:"newQueryId123",operationName:"CreateTweet"}'
+              ),
+          });
+        }
+        return Promise.reject(new Error("Unknown URL"));
+      });
+
+      store = createRuntimeQueryIdStore({
+        cachePath,
+        fetchImpl: mockFetch as typeof fetch,
+      });
+
+      const info = await store.refresh(["CreateTweet"], { force: true });
+
+      expect(info?.snapshot.ids.CreateTweet).toBe("newQueryId123");
+
+      // Verify cache was written
+      const cached = JSON.parse(await readFile(cachePath, "utf8"));
+      expect(cached.ids.CreateTweet).toBe("newQueryId123");
+    });
+
+    it("handles discovery failure gracefully", async () => {
+      const mockFetch = mock(() => Promise.reject(new Error("Network error")));
+
+      store = createRuntimeQueryIdStore({
+        cachePath,
+        fetchImpl: mockFetch as typeof fetch,
+      });
+
+      // Should throw because no bundles discovered
+      await expect(
+        store.refresh(["CreateTweet"], { force: true })
+      ).rejects.toThrow("No client bundles discovered");
+    });
+
+    it("throws on discovery failure even when stale cache exists", async () => {
+      // Stale cache exists (48 hours old, past 24hr TTL)
+      const snapshot = {
+        fetchedAt: new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString(),
+        ttlMs: 86400000,
+        ids: { CreateTweet: "stale123" },
+        discovery: { pages: [], bundles: [] },
+      };
+      await mkdir(path.dirname(cachePath), { recursive: true });
+      await writeFile(cachePath, JSON.stringify(snapshot));
+
+      // Network fails during refresh attempt
+      const mockFetch = mock(() => Promise.reject(new Error("Network error")));
+
+      store = createRuntimeQueryIdStore({
+        cachePath,
+        fetchImpl: mockFetch as typeof fetch,
+      });
+
+      // refresh() throws rather than returning stale data
+      await expect(store.refresh(["CreateTweet"])).rejects.toThrow();
+    });
+
+    it("deduplicates concurrent refresh calls", async () => {
+      const mockFetch = mock((url: string) => {
+        if (url.includes("x.com")) {
+          return Promise.resolve({
+            ok: true,
+            text: () =>
+              Promise.resolve(
+                '<script src="https://abs.twimg.com/responsive-web/client-web/bundle.js"></script>'
+              ),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          text: () =>
+            Promise.resolve(
+              'e.exports={queryId:"concurrent123",operationName:"CreateTweet"}'
+            ),
+        });
+      });
+
+      store = createRuntimeQueryIdStore({
+        cachePath,
+        fetchImpl: mockFetch as typeof fetch,
+      });
+
+      // Start two refreshes simultaneously
+      const [result1, result2] = await Promise.all([
+        store.refresh(["CreateTweet"], { force: true }),
+        store.refresh(["CreateTweet"], { force: true }),
+      ]);
+
+      // Both should return the same result
+      expect(result1?.snapshot.ids.CreateTweet).toBe("concurrent123");
+      expect(result2?.snapshot.ids.CreateTweet).toBe("concurrent123");
+    });
+
+    it("extracts query IDs with operationName first pattern", async () => {
+      const mockFetch = mock((url: string) => {
+        if (url.includes("x.com")) {
+          return Promise.resolve({
+            ok: true,
+            text: () =>
+              Promise.resolve(
+                '<script src="https://abs.twimg.com/responsive-web/client-web/main.js"></script>'
+              ),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          text: () =>
+            Promise.resolve(
+              'e.exports={operationName:"TweetDetail",queryId:"detailId456"}'
+            ),
+        });
+      });
+
+      store = createRuntimeQueryIdStore({
+        cachePath,
+        fetchImpl: mockFetch as typeof fetch,
+      });
+
+      const info = await store.refresh(["TweetDetail"], { force: true });
+      expect(info?.snapshot.ids.TweetDetail).toBe("detailId456");
+    });
+
+    it("extracts query IDs from loose patterns", async () => {
+      const mockFetch = mock((url: string) => {
+        if (url.includes("x.com")) {
+          return Promise.resolve({
+            ok: true,
+            text: () =>
+              Promise.resolve(
+                '<script src="https://abs.twimg.com/responsive-web/client-web/app.js"></script>'
+              ),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          text: () =>
+            Promise.resolve(
+              'operationName:"SearchTimeline",other:"stuff",queryId:"searchId789"'
+            ),
+        });
+      });
+
+      store = createRuntimeQueryIdStore({
+        cachePath,
+        fetchImpl: mockFetch as typeof fetch,
+      });
+
+      const info = await store.refresh(["SearchTimeline"], { force: true });
+      expect(info?.snapshot.ids.SearchTimeline).toBe("searchId789");
+    });
+
+    it("extracts query IDs with queryId first loose pattern", async () => {
+      const mockFetch = mock((url: string) => {
+        if (url.includes("x.com")) {
+          return Promise.resolve({
+            ok: true,
+            text: () =>
+              Promise.resolve(
+                '<script src="https://abs.twimg.com/responsive-web/client-web/vendor.js"></script>'
+              ),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          text: () =>
+            Promise.resolve(
+              'queryId:"bookmarkId111",foo:"bar",operationName:"Bookmarks"'
+            ),
+        });
+      });
+
+      store = createRuntimeQueryIdStore({
+        cachePath,
+        fetchImpl: mockFetch as typeof fetch,
+      });
+
+      const info = await store.refresh(["Bookmarks"], { force: true });
+      expect(info?.snapshot.ids.Bookmarks).toBe("bookmarkId111");
+    });
+
+    it("skips invalid query IDs", async () => {
+      const mockFetch = mock((url: string) => {
+        if (url.includes("x.com")) {
+          return Promise.resolve({
+            ok: true,
+            text: () =>
+              Promise.resolve(
+                '<script src="https://abs.twimg.com/responsive-web/client-web/bundle.js"></script>'
+              ),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          text: () =>
+            Promise.resolve(
+              'e.exports={queryId:"invalid@id!",operationName:"CreateTweet"}'
+            ),
+        });
+      });
+
+      store = createRuntimeQueryIdStore({
+        cachePath,
+        fetchImpl: mockFetch as typeof fetch,
+      });
+
+      const info = await store.refresh(["CreateTweet"], { force: true });
+      expect(info?.snapshot.ids.CreateTweet).toBeUndefined();
+    });
+
+    it("skips operations not in target list", async () => {
+      const mockFetch = mock((url: string) => {
+        if (url.includes("x.com")) {
+          return Promise.resolve({
+            ok: true,
+            text: () =>
+              Promise.resolve(
+                '<script src="https://abs.twimg.com/responsive-web/client-web/bundle.js"></script>'
+              ),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          text: () =>
+            Promise.resolve(
+              'e.exports={queryId:"otherId",operationName:"SomeOtherOperation"}'
+            ),
+        });
+      });
+
+      store = createRuntimeQueryIdStore({
+        cachePath,
+        fetchImpl: mockFetch as typeof fetch,
+      });
+
+      const info = await store.refresh(["CreateTweet"], { force: true });
+      expect(info?.snapshot.ids.SomeOtherOperation).toBeUndefined();
+    });
+
+    it("discovers bundles from multiple pages", async () => {
+      let pageCount = 0;
+      const mockFetch = mock((url: string) => {
+        if (url.includes("x.com") && !url.includes("abs.twimg.com")) {
+          pageCount++;
+          if (pageCount === 1) {
+            // First page fails
+            return Promise.reject(new Error("Page error"));
+          }
+          return Promise.resolve({
+            ok: true,
+            text: () =>
+              Promise.resolve(
+                '<script src="https://abs.twimg.com/responsive-web/client-web/multi.js"></script>'
+              ),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          text: () =>
+            Promise.resolve(
+              'e.exports={queryId:"multipage123",operationName:"CreateTweet"}'
+            ),
+        });
+      });
+
+      store = createRuntimeQueryIdStore({
+        cachePath,
+        fetchImpl: mockFetch as typeof fetch,
+      });
+
+      const info = await store.refresh(["CreateTweet"], { force: true });
+      expect(info?.snapshot.ids.CreateTweet).toBe("multipage123");
+    });
+
+    it("handles bundle fetch failure gracefully", async () => {
+      const mockFetch = mock((url: string) => {
+        if (url.includes("x.com") && !url.includes("abs.twimg.com")) {
+          return Promise.resolve({
+            ok: true,
+            text: () =>
+              Promise.resolve(
+                '<script src="https://abs.twimg.com/responsive-web/client-web/fail.js"></script>' +
+                  '<script src="https://abs.twimg.com/responsive-web/client-web/success.js"></script>'
+              ),
+          });
+        }
+        if (url.includes("fail.js")) {
+          return Promise.reject(new Error("Bundle error"));
+        }
+        return Promise.resolve({
+          ok: true,
+          text: () =>
+            Promise.resolve(
+              'e.exports={queryId:"success123",operationName:"CreateTweet"}'
+            ),
+        });
+      });
+
+      store = createRuntimeQueryIdStore({
+        cachePath,
+        fetchImpl: mockFetch as typeof fetch,
+      });
+
+      const info = await store.refresh(["CreateTweet"], { force: true });
+      expect(info?.snapshot.ids.CreateTweet).toBe("success123");
+    });
+
+    it("handles HTTP error from discovery page", async () => {
+      const mockFetch = mock((url: string) => {
+        if (url.includes("x.com") && !url.includes("abs.twimg.com")) {
+          return Promise.resolve({
+            ok: false,
+            status: 503,
+            text: () => Promise.resolve("Service unavailable"),
+          });
+        }
+        return Promise.reject(new Error("Should not reach"));
+      });
+
+      store = createRuntimeQueryIdStore({
+        cachePath,
+        fetchImpl: mockFetch as typeof fetch,
+      });
+
+      await expect(
+        store.refresh(["CreateTweet"], { force: true })
+      ).rejects.toThrow("No client bundles discovered");
+    });
+
+    it("processes bundles in chunks for concurrency", async () => {
+      const bundleUrls = Array.from({ length: 12 }, (_, i) => `bundle${i}.js`);
+      let bundleFetchCount = 0;
+
+      const mockFetch = mock((url: string) => {
+        if (url.includes("x.com") && !url.includes("abs.twimg.com")) {
+          const scripts = bundleUrls
+            .map(
+              (b) =>
+                `<script src="https://abs.twimg.com/responsive-web/client-web/${b}"></script>`
+            )
+            .join("");
+          return Promise.resolve({
+            ok: true,
+            text: () => Promise.resolve(scripts),
+          });
+        }
+        bundleFetchCount++;
+        // Last bundle has the ID
+        if (url.includes("bundle11.js")) {
+          return Promise.resolve({
+            ok: true,
+            text: () =>
+              Promise.resolve(
+                'e.exports={queryId:"chunked123",operationName:"CreateTweet"}'
+              ),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve("// empty bundle"),
+        });
+      });
+
+      store = createRuntimeQueryIdStore({
+        cachePath,
+        fetchImpl: mockFetch as typeof fetch,
+      });
+
+      const info = await store.refresh(["CreateTweet"], { force: true });
+      expect(info?.snapshot.ids.CreateTweet).toBe("chunked123");
+      expect(bundleFetchCount).toBe(12);
+    });
+
+    it("stops fetching bundles once all targets found", async () => {
+      const bundleUrls = ["bundle1.js", "bundle2.js", "bundle3.js"];
+
+      const mockFetch = mock((url: string) => {
+        if (url.includes("x.com") && !url.includes("abs.twimg.com")) {
+          const scripts = bundleUrls
+            .map(
+              (b) =>
+                `<script src="https://abs.twimg.com/responsive-web/client-web/${b}"></script>`
+            )
+            .join("");
+          return Promise.resolve({
+            ok: true,
+            text: () => Promise.resolve(scripts),
+          });
+        }
+        if (url.includes("bundle1.js")) {
+          return Promise.resolve({
+            ok: true,
+            text: () =>
+              Promise.resolve(
+                'e.exports={queryId:"early123",operationName:"CreateTweet"}'
+              ),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve("// empty"),
+        });
+      });
+
+      store = createRuntimeQueryIdStore({
+        cachePath,
+        fetchImpl: mockFetch as typeof fetch,
+      });
+
+      const info = await store.refresh(["CreateTweet"], { force: true });
+      expect(info?.snapshot.ids.CreateTweet).toBe("early123");
+    });
+
+    it("exits early within bundle when all targets found mid-iteration", async () => {
+      // This test verifies that extractOperations returns early (line 236)
+      // when all targets are found before the regex finishes iterating
+      const mockFetch = mock((url: string) => {
+        if (url.includes("x.com") && !url.includes("abs.twimg.com")) {
+          return Promise.resolve({
+            ok: true,
+            text: () =>
+              Promise.resolve(
+                '<script src="https://abs.twimg.com/responsive-web/client-web/bundle.js"></script>'
+              ),
+          });
+        }
+        if (url.includes("bundle.js")) {
+          // Bundle contains TWO query ID matches, but we only want ONE target
+          // CreateTweet comes first, then FavoriteTweet (which we don't need)
+          // This triggers the early return when discovered.size === targets.size
+          return Promise.resolve({
+            ok: true,
+            text: () =>
+              Promise.resolve(
+                'e.exports={queryId:"first123",operationName:"CreateTweet"};' +
+                  'e.exports={queryId:"second456",operationName:"FavoriteTweet"}'
+              ),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(""),
+        });
+      });
+
+      store = createRuntimeQueryIdStore({
+        cachePath,
+        fetchImpl: mockFetch as typeof fetch,
+      });
+
+      // Only request CreateTweet - the early exit should trigger after finding it
+      const info = await store.refresh(["CreateTweet"], { force: true });
+      expect(info?.snapshot.ids.CreateTweet).toBe("first123");
+      // FavoriteTweet should NOT be in the snapshot since we didn't request it
+      expect(info?.snapshot.ids.FavoriteTweet).toBeUndefined();
+    });
+
+    it("continues iterating after finding first target when searching for multiple", async () => {
+      // This test hits line 237 - the closing brace of the if statement
+      // which is reached when discovered.size !== targets.size
+      const mockFetch = mock((url: string) => {
+        if (url.includes("x.com") && !url.includes("abs.twimg.com")) {
+          return Promise.resolve({
+            ok: true,
+            text: () =>
+              Promise.resolve(
+                '<script src="https://abs.twimg.com/responsive-web/client-web/bundle.js"></script>'
+              ),
+          });
+        }
+        if (url.includes("bundle.js")) {
+          // Bundle contains BOTH targets - after finding first, discovered.size (1) !== targets.size (2)
+          // so we hit line 237 and continue iterating to find the second target
+          return Promise.resolve({
+            ok: true,
+            text: () =>
+              Promise.resolve(
+                'e.exports={queryId:"tweet123",operationName:"CreateTweet"};' +
+                  'e.exports={queryId:"fav456",operationName:"FavoriteTweet"}'
+              ),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve(""),
+        });
+      });
+
+      store = createRuntimeQueryIdStore({
+        cachePath,
+        fetchImpl: mockFetch as typeof fetch,
+      });
+
+      // Request BOTH targets - after finding CreateTweet, we continue to find FavoriteTweet
+      const info = await store.refresh(["CreateTweet", "FavoriteTweet"], {
+        force: true,
+      });
+      expect(info?.snapshot.ids.CreateTweet).toBe("tweet123");
+      expect(info?.snapshot.ids.FavoriteTweet).toBe("fav456");
+    });
+
+    it("returns null when no IDs discovered and no cache", async () => {
+      const mockFetch = mock((url: string) => {
+        if (url.includes("x.com") && !url.includes("abs.twimg.com")) {
+          return Promise.resolve({
+            ok: true,
+            text: () =>
+              Promise.resolve(
+                '<script src="https://abs.twimg.com/responsive-web/client-web/empty.js"></script>'
+              ),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve("// no query IDs here"),
+        });
+      });
+
+      store = createRuntimeQueryIdStore({
+        cachePath,
+        fetchImpl: mockFetch as typeof fetch,
+      });
+
+      const info = await store.refresh(["CreateTweet"], { force: true });
+      expect(info).toBeNull();
+    });
+  });
+
+  describe("clearMemory", () => {
+    it("clears cached snapshot", async () => {
+      const snapshot = {
+        fetchedAt: new Date().toISOString(),
+        ttlMs: 86400000,
+        ids: { CreateTweet: "cached123" },
+        discovery: { pages: [], bundles: [] },
+      };
+      await mkdir(path.dirname(cachePath), { recursive: true });
+      await writeFile(cachePath, JSON.stringify(snapshot));
+
+      store = createRuntimeQueryIdStore({ cachePath });
+
+      // Load into memory
+      await store.getSnapshotInfo();
+
+      // Clear memory
+      store.clearMemory();
+
+      // Delete file
+      await rm(cachePath);
+
+      // Should return null since memory cleared and file gone
+      const info = await store.getSnapshotInfo();
+      expect(info).toBeNull();
+    });
+  });
+
+  describe("XFEED_QUERY_IDS_CACHE environment variable", () => {
+    const originalEnv = process.env.XFEED_QUERY_IDS_CACHE;
+
+    afterEach(() => {
+      if (originalEnv !== undefined) {
+        process.env.XFEED_QUERY_IDS_CACHE = originalEnv;
+      } else {
+        delete process.env.XFEED_QUERY_IDS_CACHE;
+      }
+    });
+
+    it("uses XFEED_QUERY_IDS_CACHE when set", () => {
+      process.env.XFEED_QUERY_IDS_CACHE = "/custom/cache/path.json";
+      store = createRuntimeQueryIdStore();
+      expect(store.cachePath).toBe("/custom/cache/path.json");
+    });
+
+    it("ignores empty XFEED_QUERY_IDS_CACHE", () => {
+      process.env.XFEED_QUERY_IDS_CACHE = "   ";
+      store = createRuntimeQueryIdStore();
+      expect(store.cachePath).not.toBe("   ");
+      expect(store.cachePath).toContain("query-ids-cache.json");
+    });
+  });
+
+  describe("legacy bundle URL patterns", () => {
+    it("discovers legacy client bundles", async () => {
+      const mockFetch = mock((url: string) => {
+        if (url.includes("x.com") && !url.includes("abs.twimg.com")) {
+          return Promise.resolve({
+            ok: true,
+            text: () =>
+              Promise.resolve(
+                '<script src="https://abs.twimg.com/responsive-web/client-web-legacy/bundle.abc.js"></script>'
+              ),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          text: () =>
+            Promise.resolve(
+              'e.exports={queryId:"legacy123",operationName:"CreateTweet"}'
+            ),
+        });
+      });
+
+      store = createRuntimeQueryIdStore({
+        cachePath,
+        fetchImpl: mockFetch as typeof fetch,
+      });
+
+      const info = await store.refresh(["CreateTweet"], { force: true });
+      expect(info?.snapshot.ids.CreateTweet).toBe("legacy123");
+    });
+  });
+});

--- a/src/auth/cookies.test.ts
+++ b/src/auth/cookies.test.ts
@@ -1,0 +1,529 @@
+// @ts-nocheck - Test file with module mocking
+/**
+ * Unit tests for cookies.ts
+ * Tests cookie extraction and credential resolution
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+// Create a wrapper that we can update
+let mockImpl = () =>
+  Promise.resolve({
+    cookies: [] as Array<{ name?: string; value?: string; domain?: string }>,
+    warnings: [] as string[],
+  });
+
+// Mock the sweet-cookie module - the wrapper calls mockImpl which can be updated
+mock.module("@steipete/sweet-cookie", () => ({
+  getCookies: () => mockImpl(),
+}));
+
+// Now import the module under test (after mocking)
+const {
+  extractCookiesFromChrome,
+  extractCookiesFromFirefox,
+  extractCookiesFromSafari,
+  resolveCredentials,
+} = await import("./cookies");
+
+// Helper to set mock implementation
+function setMockCookies(
+  cookies: Array<{ name?: string; value?: string; domain?: string }>,
+  warnings: string[] = []
+) {
+  mockImpl = () => Promise.resolve({ cookies, warnings });
+}
+
+// Helper for stateful mocks
+function setMockCookiesSequence(
+  responses: Array<{
+    cookies: Array<{ name?: string; value?: string; domain?: string }>;
+    warnings: string[];
+  }>
+) {
+  let callCount = 0;
+  mockImpl = () => {
+    const response = responses[callCount] ?? { cookies: [], warnings: [] };
+    callCount++;
+    return Promise.resolve(response);
+  };
+}
+
+describe("cookies", () => {
+  beforeEach(() => {
+    // Reset mock to default
+    mockImpl = () => Promise.resolve({ cookies: [], warnings: [] });
+
+    // Clear environment variables
+    delete process.env.AUTH_TOKEN;
+    delete process.env.TWITTER_AUTH_TOKEN;
+    delete process.env.CT0;
+    delete process.env.TWITTER_CT0;
+  });
+
+  afterEach(() => {
+    delete process.env.AUTH_TOKEN;
+    delete process.env.TWITTER_AUTH_TOKEN;
+    delete process.env.CT0;
+    delete process.env.TWITTER_CT0;
+  });
+
+  describe("resolveCredentials", () => {
+    it("uses CLI arguments when provided", async () => {
+      const result = await resolveCredentials({
+        authToken: "cli-auth-token",
+        ct0: "cli-ct0",
+      });
+
+      expect(result.cookies.authToken).toBe("cli-auth-token");
+      expect(result.cookies.ct0).toBe("cli-ct0");
+      expect(result.cookies.source).toBe("CLI argument");
+      expect(result.cookies.cookieHeader).toBe(
+        "auth_token=cli-auth-token; ct0=cli-ct0"
+      );
+    });
+
+    it("uses environment variables when CLI args not provided", async () => {
+      process.env.AUTH_TOKEN = "env-auth-token";
+      process.env.CT0 = "env-ct0";
+
+      const result = await resolveCredentials({});
+
+      expect(result.cookies.authToken).toBe("env-auth-token");
+      expect(result.cookies.ct0).toBe("env-ct0");
+      expect(result.cookies.source).toBe("env AUTH_TOKEN");
+    });
+
+    it("uses TWITTER_ prefixed environment variables", async () => {
+      process.env.TWITTER_AUTH_TOKEN = "twitter-auth-token";
+      process.env.TWITTER_CT0 = "twitter-ct0";
+
+      const result = await resolveCredentials({});
+
+      expect(result.cookies.authToken).toBe("twitter-auth-token");
+      expect(result.cookies.ct0).toBe("twitter-ct0");
+    });
+
+    it("prefers non-prefixed env vars over prefixed", async () => {
+      process.env.AUTH_TOKEN = "auth-token-1";
+      process.env.TWITTER_AUTH_TOKEN = "auth-token-2";
+
+      const result = await resolveCredentials({});
+
+      expect(result.cookies.authToken).toBe("auth-token-1");
+    });
+
+    it("falls back to browser cookies when env vars not set", async () => {
+      setMockCookies([
+        { name: "auth_token", value: "browser-auth", domain: ".x.com" },
+        { name: "ct0", value: "browser-ct0", domain: ".x.com" },
+      ]);
+
+      const result = await resolveCredentials({});
+
+      expect(result.cookies.authToken).toBe("browser-auth");
+      expect(result.cookies.ct0).toBe("browser-ct0");
+      expect(result.cookies.source).toBe("Safari");
+    });
+
+    it("tries multiple browser sources in order", async () => {
+      setMockCookiesSequence([
+        // Safari fails
+        { cookies: [], warnings: ["Safari failed"] },
+        // Chrome succeeds
+        {
+          cookies: [
+            { name: "auth_token", value: "chrome-auth", domain: ".x.com" },
+            { name: "ct0", value: "chrome-ct0", domain: ".x.com" },
+          ],
+          warnings: [],
+        },
+      ]);
+
+      const result = await resolveCredentials({});
+
+      expect(result.cookies.authToken).toBe("chrome-auth");
+      expect(result.cookies.source).toBe("Chrome default profile");
+    });
+
+    it("uses specific cookie source when provided", async () => {
+      setMockCookies([
+        { name: "auth_token", value: "firefox-auth", domain: ".x.com" },
+        { name: "ct0", value: "firefox-ct0", domain: ".x.com" },
+      ]);
+
+      const result = await resolveCredentials({ cookieSource: "firefox" });
+
+      expect(result.cookies.authToken).toBe("firefox-auth");
+      expect(result.cookies.source).toBe("Firefox default profile");
+    });
+
+    it("uses array of cookie sources", async () => {
+      setMockCookiesSequence([
+        // Chrome fails
+        { cookies: [], warnings: [] },
+        // Firefox succeeds
+        {
+          cookies: [
+            { name: "auth_token", value: "ff-auth", domain: ".x.com" },
+            { name: "ct0", value: "ff-ct0", domain: ".x.com" },
+          ],
+          warnings: [],
+        },
+      ]);
+
+      const result = await resolveCredentials({
+        cookieSource: ["chrome", "firefox"],
+      });
+
+      expect(result.cookies.authToken).toBe("ff-auth");
+    });
+
+    it("includes Chrome profile in source label", async () => {
+      setMockCookies([
+        { name: "auth_token", value: "profile-auth", domain: ".x.com" },
+        { name: "ct0", value: "profile-ct0", domain: ".x.com" },
+      ]);
+
+      const result = await resolveCredentials({
+        cookieSource: "chrome",
+        chromeProfile: "Work",
+      });
+
+      expect(result.cookies.source).toBe('Chrome profile "Work"');
+    });
+
+    it("includes Firefox profile in source label", async () => {
+      setMockCookies([
+        { name: "auth_token", value: "ff-auth", domain: ".x.com" },
+        { name: "ct0", value: "ff-ct0", domain: ".x.com" },
+      ]);
+
+      const result = await resolveCredentials({
+        cookieSource: "firefox",
+        firefoxProfile: "default-release",
+      });
+
+      expect(result.cookies.source).toBe('Firefox profile "default-release"');
+    });
+
+    it("adds warnings when cookies not found", async () => {
+      setMockCookies([], ["No cookies found"]);
+
+      const result = await resolveCredentials({});
+
+      expect(result.warnings.length).toBeGreaterThan(0);
+      expect(result.warnings.some((w) => w.includes("auth_token"))).toBe(true);
+      expect(result.warnings.some((w) => w.includes("ct0"))).toBe(true);
+    });
+
+    it("adds browser-specific warnings", async () => {
+      const result = await resolveCredentials({ cookieSource: "safari" });
+
+      expect(result.warnings.some((w) => w.includes("Safari"))).toBe(true);
+    });
+
+    it("adds Chrome-specific warning", async () => {
+      const result = await resolveCredentials({ cookieSource: "chrome" });
+
+      expect(result.warnings.some((w) => w.includes("Chrome"))).toBe(true);
+    });
+
+    it("adds Firefox-specific warning", async () => {
+      const result = await resolveCredentials({ cookieSource: "firefox" });
+
+      expect(result.warnings.some((w) => w.includes("Firefox"))).toBe(true);
+    });
+
+    it("prefers x.com domain over twitter.com", async () => {
+      setMockCookies([
+        { name: "auth_token", value: "twitter-auth", domain: ".twitter.com" },
+        { name: "auth_token", value: "x-auth", domain: ".x.com" },
+        { name: "ct0", value: "x-ct0", domain: ".x.com" },
+      ]);
+
+      const result = await resolveCredentials({});
+
+      expect(result.cookies.authToken).toBe("x-auth");
+    });
+
+    it("uses twitter.com domain if x.com not available", async () => {
+      setMockCookies([
+        { name: "auth_token", value: "twitter-auth", domain: ".twitter.com" },
+        { name: "ct0", value: "twitter-ct0", domain: ".twitter.com" },
+      ]);
+
+      const result = await resolveCredentials({});
+
+      expect(result.cookies.authToken).toBe("twitter-auth");
+    });
+
+    it("uses first cookie if no domain preference matches", async () => {
+      setMockCookies([
+        { name: "auth_token", value: "other-auth", domain: ".other.com" },
+        { name: "ct0", value: "other-ct0", domain: ".other.com" },
+      ]);
+
+      const result = await resolveCredentials({});
+
+      expect(result.cookies.authToken).toBe("other-auth");
+    });
+
+    it("discards partial browser cookies (only auth_token found)", async () => {
+      // Browser only finds auth_token, not ct0
+      // Current behavior: partial browser results are discarded, warnings added
+      setMockCookies([
+        { name: "auth_token", value: "partial-auth", domain: ".x.com" },
+      ]);
+
+      const result = await resolveCredentials({});
+
+      // Browser partial match is discarded, so both are null
+      expect(result.cookies.authToken).toBeNull();
+      expect(result.cookies.ct0).toBeNull();
+      // Warnings for both missing
+      expect(result.warnings.some((w) => w.includes("auth_token"))).toBe(true);
+      expect(result.warnings.some((w) => w.includes("ct0"))).toBe(true);
+    });
+
+    it("ignores empty string env values", async () => {
+      process.env.AUTH_TOKEN = "   ";
+      process.env.CT0 = "";
+
+      setMockCookies([
+        { name: "auth_token", value: "browser-auth", domain: ".x.com" },
+        { name: "ct0", value: "browser-ct0", domain: ".x.com" },
+      ]);
+
+      const result = await resolveCredentials({});
+
+      expect(result.cookies.authToken).toBe("browser-auth");
+    });
+
+    it("combines CLI args with env vars", async () => {
+      process.env.CT0 = "env-ct0";
+
+      const result = await resolveCredentials({
+        authToken: "cli-auth",
+      });
+
+      expect(result.cookies.authToken).toBe("cli-auth");
+      expect(result.cookies.ct0).toBe("env-ct0");
+      expect(result.cookies.source).toBe("CLI argument");
+    });
+
+    it("sets source from ct0 when authToken not from CLI", async () => {
+      const result = await resolveCredentials({
+        ct0: "cli-ct0-only",
+      });
+
+      expect(result.cookies.ct0).toBe("cli-ct0-only");
+      expect(result.cookies.source).toBe("CLI argument");
+    });
+
+    it("collects warnings from provider", async () => {
+      setMockCookies([], ["Provider warning 1", "Provider warning 2"]);
+
+      const result = await resolveCredentials({});
+
+      expect(result.warnings).toContain("Provider warning 1");
+      expect(result.warnings).toContain("Provider warning 2");
+    });
+
+    it("handles cookies with missing value", async () => {
+      // Cookie exists but has no value - treated as not found
+      // Since we only have ct0 (auth_token has no value), partial match is discarded
+      setMockCookies([
+        { name: "auth_token" },
+        { name: "ct0", value: "valid-ct0", domain: ".x.com" },
+      ]);
+
+      const result = await resolveCredentials({});
+
+      // Browser partial match (only ct0) is discarded
+      expect(result.cookies.authToken).toBeNull();
+      expect(result.cookies.ct0).toBeNull();
+    });
+
+    it("builds cookieHeader when both cookies found from partial sources", async () => {
+      process.env.AUTH_TOKEN = "env-auth";
+
+      // Only auth from env, ct0 not found
+      const result = await resolveCredentials({});
+
+      // cookieHeader should be null since ct0 is missing
+      expect(result.cookies.cookieHeader).toBeNull();
+    });
+
+    it("builds cookieHeader when both found from different sources", async () => {
+      process.env.AUTH_TOKEN = "env-auth";
+      process.env.CT0 = "env-ct0";
+
+      const result = await resolveCredentials({});
+
+      expect(result.cookies.cookieHeader).toBe(
+        "auth_token=env-auth; ct0=env-ct0"
+      );
+    });
+  });
+
+  describe("extractCookiesFromSafari", () => {
+    it("extracts cookies from Safari", async () => {
+      setMockCookies([
+        { name: "auth_token", value: "safari-auth", domain: ".x.com" },
+        { name: "ct0", value: "safari-ct0", domain: ".x.com" },
+      ]);
+
+      const result = await extractCookiesFromSafari();
+
+      expect(result.cookies.authToken).toBe("safari-auth");
+      expect(result.cookies.ct0).toBe("safari-ct0");
+      expect(result.cookies.source).toBe("Safari");
+    });
+
+    it("adds warning when Safari cookies not found", async () => {
+      const result = await extractCookiesFromSafari();
+
+      expect(result.cookies.authToken).toBeNull();
+      expect(result.warnings.some((w) => w.includes("Safari"))).toBe(true);
+    });
+  });
+
+  describe("extractCookiesFromChrome", () => {
+    it("extracts cookies from Chrome default profile", async () => {
+      setMockCookies([
+        { name: "auth_token", value: "chrome-auth", domain: ".x.com" },
+        { name: "ct0", value: "chrome-ct0", domain: ".x.com" },
+      ]);
+
+      const result = await extractCookiesFromChrome();
+
+      expect(result.cookies.authToken).toBe("chrome-auth");
+      expect(result.cookies.source).toBe("Chrome default profile");
+    });
+
+    it("extracts cookies from Chrome specific profile", async () => {
+      setMockCookies([
+        { name: "auth_token", value: "profile-auth", domain: ".x.com" },
+        { name: "ct0", value: "profile-ct0", domain: ".x.com" },
+      ]);
+
+      const result = await extractCookiesFromChrome("Personal");
+
+      expect(result.cookies.source).toBe('Chrome profile "Personal"');
+    });
+
+    it("adds warning when Chrome cookies not found", async () => {
+      const result = await extractCookiesFromChrome();
+
+      expect(result.warnings.some((w) => w.includes("Chrome"))).toBe(true);
+    });
+  });
+
+  describe("extractCookiesFromFirefox", () => {
+    it("extracts cookies from Firefox default profile", async () => {
+      setMockCookies([
+        { name: "auth_token", value: "firefox-auth", domain: ".x.com" },
+        { name: "ct0", value: "firefox-ct0", domain: ".x.com" },
+      ]);
+
+      const result = await extractCookiesFromFirefox();
+
+      expect(result.cookies.authToken).toBe("firefox-auth");
+      expect(result.cookies.source).toBe("Firefox default profile");
+    });
+
+    it("extracts cookies from Firefox specific profile", async () => {
+      setMockCookies([
+        { name: "auth_token", value: "ff-auth", domain: ".x.com" },
+        { name: "ct0", value: "ff-ct0", domain: ".x.com" },
+      ]);
+
+      const result = await extractCookiesFromFirefox("dev-edition-default");
+
+      expect(result.cookies.source).toBe(
+        'Firefox profile "dev-edition-default"'
+      );
+    });
+
+    it("adds warning when Firefox cookies not found", async () => {
+      const result = await extractCookiesFromFirefox();
+
+      expect(result.warnings.some((w) => w.includes("Firefox"))).toBe(true);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles cookies with undefined domain", async () => {
+      setMockCookies([
+        { name: "auth_token", value: "no-domain-auth" },
+        { name: "ct0", value: "no-domain-ct0" },
+      ]);
+
+      const result = await resolveCredentials({});
+
+      expect(result.cookies.authToken).toBe("no-domain-auth");
+      expect(result.cookies.ct0).toBe("no-domain-ct0");
+    });
+
+    it("handles cookies with empty value string", async () => {
+      // Empty string value is falsy, so the auth check fails (authToken && ct0)
+      // This means partial match is discarded
+      setMockCookies([
+        { name: "auth_token", value: "", domain: ".x.com" },
+        { name: "ct0", value: "valid-ct0", domain: ".x.com" },
+      ]);
+
+      const result = await resolveCredentials({});
+
+      // Empty string makes the truthy check fail, so both are null
+      expect(result.cookies.authToken).toBeNull();
+      expect(result.cookies.ct0).toBeNull();
+    });
+
+    it("handles non-string cookie values", async () => {
+      // Non-string auth_token is ignored, so partial match (only ct0) is discarded
+      setMockCookies([
+        {
+          name: "auth_token",
+          value: 12345 as unknown as string,
+          domain: ".x.com",
+        },
+        { name: "ct0", value: "valid-ct0", domain: ".x.com" },
+      ]);
+
+      const result = await resolveCredentials({});
+
+      // Partial browser match is discarded
+      expect(result.cookies.authToken).toBeNull();
+      expect(result.cookies.ct0).toBeNull();
+    });
+
+    it("handles undefined cookie objects", async () => {
+      // Undefined objects are skipped, partial match (only ct0) is discarded
+      setMockCookies([
+        undefined as unknown as { name: string; value: string },
+        { name: "ct0", value: "valid-ct0", domain: ".x.com" },
+      ]);
+
+      const result = await resolveCredentials({});
+
+      // Partial browser match is discarded
+      expect(result.cookies.ct0).toBeNull();
+    });
+
+    it("handles null cookie objects", async () => {
+      // Null objects are skipped, but both valid cookies are found
+      setMockCookies([
+        null as unknown as { name: string; value: string },
+        { name: "auth_token", value: "valid-auth", domain: ".x.com" },
+        { name: "ct0", value: "valid-ct0", domain: ".x.com" },
+      ]);
+
+      const result = await resolveCredentials({});
+
+      expect(result.cookies.authToken).toBe("valid-auth");
+      expect(result.cookies.ct0).toBe("valid-ct0");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Establishes comprehensive test infrastructure for xfeed using Bun's built-in test runner, achieving **99.77% line coverage** across the API layer.

### What's Included

- **179 tests** across 4 test files
- **100% coverage** on `client.ts` and `query-ids.ts`
- **Test scripts** added to package.json
- **Bun test skill** for Claude Code assistance

### Test Files

| File | Tests | Coverage | Description |
|------|-------|----------|-------------|
| `client.test.ts` | 88 | 100% | TwitterClient API methods |
| `runtime-query-ids.test.ts` | 51 | 99.66% | Query ID discovery & caching |
| `query-ids.test.ts` | 10 | 100% | Query ID constants |
| `cookies.test.ts` | 30 | 99.44% | Cookie extraction |

### Scripts Added

```bash
bun test              # Run all tests
bun test --watch      # Watch mode
bun test --coverage   # Coverage report
```

### Testing Patterns Established

- ✅ Mock `fetch` with proper type handling (`@ts-nocheck` for Bun's strict types)
- ✅ Module mocking with `mock.module()` for external dependencies
- ✅ Spy restoration in `afterAll` for proper cleanup
- ✅ Per-test temp directories with `mkdtemp()` for isolation
- ✅ Environment variable save/restore patterns

### Claude Code Skill

Added `.claude/skills/bun-test/` with:
- `SKILL.md` - Comprehensive Bun test guide
- `PATTERNS.md` - xfeed-specific test patterns

## Test Plan

- [x] `bun test` runs and passes (179 tests)
- [x] `bun test --coverage` generates report
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes (5 warnings for empty TODO files)

## Related

- Closes #16
- Follow-up: #18 (CI/CD setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)