### PR TITLE
feat(tui): Post list with vim-style navigation

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -6,6 +6,7 @@ import type { UserData } from "@/api/types";
 
 import { Footer } from "@/components/Footer";
 import { Header } from "@/components/Header";
+import { TimelineScreen } from "@/screens/TimelineScreen";
 
 export type View = "timeline" | "bookmarks";
 
@@ -16,9 +17,10 @@ interface AppProps {
   user: UserData;
 }
 
-export function App({ client: _client, user }: AppProps) {
+export function App({ client, user: _user }: AppProps) {
   const renderer = useRenderer();
   const [currentView, setCurrentView] = useState<View>("timeline");
+  const [postCount, setPostCount] = useState(0);
 
   useKeyboard((key) => {
     // Quit on q or Escape
@@ -44,20 +46,25 @@ export function App({ client: _client, user }: AppProps) {
         height: "100%",
       }}
     >
-      <Header currentView={currentView} />
+      <Header currentView={currentView} postCount={postCount} />
 
-      {/* Content area - placeholder for now */}
+      {/* Content area */}
       <box
         style={{
           flexGrow: 1,
-          padding: 1,
         }}
       >
-        <text fg="#888888">
-          {currentView === "timeline"
-            ? `Timeline view coming soon... (@${user.username})`
-            : "Bookmarks view coming soon..."}
-        </text>
+        {currentView === "timeline" ? (
+          <TimelineScreen
+            client={client}
+            focused={true}
+            onPostCountChange={setPostCount}
+          />
+        ) : (
+          <box style={{ padding: 2 }}>
+            <text fg="#888888">Bookmarks view coming soon...</text>
+          </box>
+        )}
       </box>
 
       <Footer />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,9 +2,10 @@ import type { View } from "@/app";
 
 interface HeaderProps {
   currentView: View;
+  postCount?: number;
 }
 
-export function Header({ currentView }: HeaderProps) {
+export function Header({ currentView, postCount }: HeaderProps) {
   const viewLabel = currentView.charAt(0).toUpperCase() + currentView.slice(1);
 
   return (
@@ -20,6 +21,9 @@ export function Header({ currentView }: HeaderProps) {
       <text fg="#1DA1F2">xfeed</text>
       <text fg="#666666"> | </text>
       <text fg="#ffffff">{viewLabel}</text>
+      {postCount !== undefined && postCount > 0 && (
+        <text fg="#666666"> ({postCount} posts)</text>
+      )}
     </box>
   );
 }

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -1,0 +1,71 @@
+/**
+ * PostCard - Individual post display component
+ */
+
+import type { TweetData } from "@/api/types";
+
+import { formatCount, formatRelativeTime, truncateText } from "@/lib/format";
+
+const MAX_TEXT_LINES = 3;
+const SELECTED_BG = "#1a1a2e";
+const X_BLUE = "#1DA1F2";
+
+interface PostCardProps {
+  post: TweetData;
+  isSelected: boolean;
+  id?: string;
+}
+
+export function PostCard({ post, isSelected, id }: PostCardProps) {
+  const displayText = truncateText(post.text, MAX_TEXT_LINES);
+  const timeAgo = formatRelativeTime(post.createdAt);
+
+  return (
+    <box
+      id={id}
+      style={{
+        flexDirection: "row",
+        marginBottom: 1,
+        backgroundColor: isSelected ? SELECTED_BG : undefined,
+      }}
+    >
+      {/* Selection indicator */}
+      <box style={{ width: 2, flexShrink: 0 }}>
+        <text fg={X_BLUE}>{isSelected ? "> " : "  "}</text>
+      </box>
+
+      {/* Post content */}
+      <box
+        style={{
+          flexDirection: "column",
+          flexGrow: 1,
+          padding: 1,
+        }}
+      >
+        {/* Author line */}
+        <box style={{ flexDirection: "row" }}>
+          <text fg={X_BLUE}>@{post.author.username}</text>
+          <text fg="#666666">
+            {" "}
+            · {post.author.name}
+            {timeAgo ? ` · ${timeAgo}` : ""}
+          </text>
+        </box>
+
+        {/* Post text */}
+        <box style={{ marginTop: 1 }}>
+          <text fg="#ffffff">{displayText}</text>
+        </box>
+
+        {/* Stats line */}
+        <box style={{ flexDirection: "row", marginTop: 1 }}>
+          <text fg="#888888">
+            {formatCount(post.replyCount)} replies {"  "}
+            {formatCount(post.retweetCount)} reposts {"  "}
+            {formatCount(post.likeCount)} likes
+          </text>
+        </box>
+      </box>
+    </box>
+  );
+}

--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -1,0 +1,121 @@
+/**
+ * PostList - Scrollable list of posts with vim-style navigation
+ */
+
+import type { ScrollBoxRenderable } from "@opentui/core";
+
+import { useEffect, useRef } from "react";
+
+import type { TweetData } from "@/api/types";
+
+import { PostCard } from "@/components/PostCard";
+import { useListNavigation } from "@/hooks/useListNavigation";
+
+interface PostListProps {
+  posts: TweetData[];
+  focused?: boolean;
+  onPostSelect?: (post: TweetData) => void;
+}
+
+/**
+ * Generate element ID from tweet ID for scroll targeting
+ */
+function getPostCardId(tweetId: string): string {
+  return `post-${tweetId}`;
+}
+
+export function PostList({
+  posts,
+  focused = false,
+  onPostSelect,
+}: PostListProps) {
+  const scrollRef = useRef<ScrollBoxRenderable>(null);
+
+  const { selectedIndex } = useListNavigation({
+    itemCount: posts.length,
+    enabled: focused,
+    onSelect: (index) => {
+      const post = posts[index];
+      if (post) {
+        onPostSelect?.(post);
+      }
+    },
+  });
+
+  // Scroll to keep selected item visible with context (scroll margin)
+  // Similar to Vim's scrolloff - keeps items visible above/below selection
+  useEffect(() => {
+    const scrollbox = scrollRef.current;
+    if (!scrollbox || posts.length === 0) return;
+
+    // Find the selected element by tweet ID
+    const selectedPost = posts[selectedIndex];
+    if (!selectedPost) return;
+
+    const targetId = getPostCardId(selectedPost.id);
+    const target = scrollbox
+      .getChildren()
+      .find((child) => child.id === targetId);
+    if (!target) return;
+
+    // Calculate the element's position relative to the scrollbox viewport
+    const relativeY = target.y - scrollbox.y;
+    const viewportHeight = scrollbox.viewport.height;
+
+    // Asymmetric scroll margins - selected item biased towards top of viewport
+    // Small top margin (keeps selection near top), large bottom margin (shows more below)
+    const topMargin = Math.max(1, Math.floor(viewportHeight / 10)); // ~10% from top
+    const bottomMargin = Math.max(4, Math.floor(viewportHeight / 3)); // ~33% from bottom
+
+    // First item: always scroll to absolute top
+    if (selectedIndex === 0) {
+      scrollbox.scrollTo(0);
+      return;
+    }
+
+    // Last item: always scroll to absolute bottom
+    if (selectedIndex === posts.length - 1) {
+      scrollbox.scrollTo(scrollbox.scrollHeight);
+      return;
+    }
+
+    // If element is too close to bottom, scroll up so it's in upper portion
+    if (relativeY + target.height > viewportHeight - bottomMargin) {
+      scrollbox.scrollBy(
+        relativeY + target.height - viewportHeight + bottomMargin
+      );
+    }
+    // If element is too close to top, scroll down to add small margin
+    else if (relativeY < topMargin) {
+      scrollbox.scrollBy(relativeY - topMargin);
+    }
+  }, [selectedIndex, posts.length]);
+
+  if (posts.length === 0) {
+    return (
+      <box style={{ padding: 2 }}>
+        <text fg="#888888">No posts to display</text>
+      </box>
+    );
+  }
+
+  return (
+    <scrollbox
+      ref={scrollRef}
+      focused={focused}
+      style={{
+        flexGrow: 1,
+        height: "100%",
+      }}
+    >
+      {posts.map((post, index) => (
+        <PostCard
+          key={post.id}
+          id={getPostCardId(post.id)}
+          post={post}
+          isSelected={index === selectedIndex}
+        />
+      ))}
+    </scrollbox>
+  );
+}

--- a/src/hooks/useListNavigation.ts
+++ b/src/hooks/useListNavigation.ts
@@ -1,0 +1,110 @@
+/**
+ * Vim-style list navigation hook
+ * Provides j/k navigation, g/G jump to top/bottom, Enter to select
+ */
+
+import { useKeyboard } from "@opentui/react";
+import { useState, useCallback } from "react";
+
+export interface UseListNavigationOptions {
+  /** Total number of items in the list */
+  itemCount: number;
+  /** Callback when Enter is pressed on current selection */
+  onSelect?: (index: number) => void;
+  /** Whether this component should handle keyboard input */
+  enabled?: boolean;
+}
+
+export interface UseListNavigationResult {
+  /** Currently selected index */
+  selectedIndex: number;
+  /** Set the selected index directly */
+  setSelectedIndex: (index: number | ((prev: number) => number)) => void;
+  /** Move selection up by one */
+  moveUp: () => void;
+  /** Move selection down by one */
+  moveDown: () => void;
+  /** Jump to first item */
+  jumpToTop: () => void;
+  /** Jump to last item */
+  jumpToBottom: () => void;
+}
+
+export function useListNavigation({
+  itemCount,
+  onSelect,
+  enabled = true,
+}: UseListNavigationOptions): UseListNavigationResult {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  const clampIndex = useCallback(
+    (index: number): number => {
+      if (itemCount === 0) return 0;
+      return Math.max(0, Math.min(index, itemCount - 1));
+    },
+    [itemCount]
+  );
+
+  const moveUp = useCallback(() => {
+    setSelectedIndex((prev) => clampIndex(prev - 1));
+  }, [clampIndex]);
+
+  const moveDown = useCallback(() => {
+    setSelectedIndex((prev) => clampIndex(prev + 1));
+  }, [clampIndex]);
+
+  const jumpToTop = useCallback(() => {
+    setSelectedIndex(0);
+  }, []);
+
+  const jumpToBottom = useCallback(() => {
+    setSelectedIndex(clampIndex(itemCount - 1));
+  }, [clampIndex, itemCount]);
+
+  useKeyboard((key) => {
+    if (!enabled || itemCount === 0) return;
+
+    switch (key.name) {
+      case "j":
+      case "down":
+        moveDown();
+        break;
+      case "k":
+      case "up":
+        moveUp();
+        break;
+      case "g":
+        // g = top, G (shift+g) = bottom
+        // OpenTUI reports shift+g as "G" (uppercase)
+        jumpToTop();
+        break;
+      case "G":
+        jumpToBottom();
+        break;
+      case "return":
+        onSelect?.(selectedIndex);
+        break;
+    }
+  });
+
+  // Ensure selected index stays in bounds when itemCount changes
+  const safeSelectedIndex = clampIndex(selectedIndex);
+  if (safeSelectedIndex !== selectedIndex) {
+    setSelectedIndex(safeSelectedIndex);
+  }
+
+  return {
+    selectedIndex: safeSelectedIndex,
+    setSelectedIndex: (indexOrFn) => {
+      if (typeof indexOrFn === "function") {
+        setSelectedIndex((prev) => clampIndex(indexOrFn(prev)));
+      } else {
+        setSelectedIndex(clampIndex(indexOrFn));
+      }
+    },
+    moveUp,
+    moveDown,
+    jumpToTop,
+    jumpToBottom,
+  };
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -64,7 +64,7 @@ cli
 
       // Launch TUI
       const renderer = await createCliRenderer({
-        exitOnCtrlC: false,
+        exitOnCtrlC: true,
       });
 
       createRoot(renderer).render(

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,59 @@
+/**
+ * Formatting utilities for xfeed TUI
+ */
+
+/**
+ * Format a timestamp as relative time (e.g., "2h", "5d", "Jan 15")
+ */
+export function formatRelativeTime(dateString?: string): string {
+  if (!dateString) return "";
+
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMins / 60);
+  const diffDays = Math.floor(diffHours / 24);
+
+  if (diffMins < 1) return "now";
+  if (diffMins < 60) return `${diffMins}m`;
+  if (diffHours < 24) return `${diffHours}h`;
+  if (diffDays < 7) return `${diffDays}d`;
+
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+/**
+ * Truncate text to a maximum number of lines
+ */
+export function truncateText(
+  text: string,
+  maxLines: number,
+  maxCharsPerLine = 80
+): string {
+  const lines = text.split("\n").slice(0, maxLines);
+  const truncated = lines.map((line) =>
+    line.length > maxCharsPerLine
+      ? `${line.slice(0, maxCharsPerLine - 3)}...`
+      : line
+  );
+
+  if (text.split("\n").length > maxLines) {
+    const lastLine = truncated[truncated.length - 1];
+    if (lastLine && !lastLine.endsWith("...")) {
+      truncated[truncated.length - 1] = `${lastLine}...`;
+    }
+  }
+
+  return truncated.join("\n");
+}
+
+/**
+ * Format stat count with K/M suffixes
+ */
+export function formatCount(count?: number): string {
+  if (count === undefined || count === 0) return "0";
+  if (count < 1000) return String(count);
+  if (count < 1000000) return `${(count / 1000).toFixed(1)}K`;
+  return `${(count / 1000000).toFixed(1)}M`;
+}

--- a/src/screens/TimelineScreen.tsx
+++ b/src/screens/TimelineScreen.tsx
@@ -1,0 +1,77 @@
+/**
+ * TimelineScreen - Displays the user's timeline
+ */
+
+import { useState, useEffect } from "react";
+
+import type { TwitterClient } from "@/api/client";
+import type { TweetData } from "@/api/types";
+
+import { PostList } from "@/components/PostList";
+
+interface TimelineScreenProps {
+  client: TwitterClient;
+  focused?: boolean;
+  onPostCountChange?: (count: number) => void;
+}
+
+export function TimelineScreen({
+  client,
+  focused = false,
+  onPostCountChange,
+}: TimelineScreenProps) {
+  const [posts, setPosts] = useState<TweetData[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Report post count to parent
+  useEffect(() => {
+    onPostCountChange?.(posts.length);
+  }, [posts.length, onPostCountChange]);
+
+  useEffect(() => {
+    async function fetchTimeline() {
+      setLoading(true);
+      setError(null);
+
+      const result = await client.getHomeLatestTimeline(30);
+
+      if (result.success) {
+        setPosts(result.tweets);
+      } else {
+        setError(result.error);
+      }
+
+      setLoading(false);
+    }
+
+    fetchTimeline();
+  }, [client]);
+
+  if (loading) {
+    return (
+      <box style={{ padding: 2 }}>
+        <text fg="#888888">Loading timeline...</text>
+      </box>
+    );
+  }
+
+  if (error) {
+    return (
+      <box style={{ padding: 2 }}>
+        <text fg="#ff6666">Error: {error}</text>
+      </box>
+    );
+  }
+
+  return (
+    <PostList
+      posts={posts}
+      focused={focused}
+      onPostSelect={(_post) => {
+        // Future: expand post detail view
+        // For now, we just highlight - Enter does nothing visible yet
+      }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

- Implements PostCard component for displaying individual posts with author info, text preview, and engagement stats
- Adds PostList scrollable container with vim-style keyboard navigation (j/k for up/down, g/G for top/bottom, Enter for select)
- Creates useListNavigation hook encapsulating vim-style navigation logic
- Integrates TimelineScreen that fetches and displays posts from the home timeline
- Adds format utilities for relative time display, count formatting, and text truncation
- Fixes scroll-to-selection to keep selected item visible with asymmetric margins
- Fixes Ctrl+C to properly exit the application

## Test plan

- [x] Run `bun run typecheck` to verify type safety
- [x] Run `bun run lint` to verify code quality
- [ ] Launch app with `bun run start` and verify timeline loads
- [ ] Test vim-style navigation: j/k moves selection, g/G jumps to top/bottom
- [ ] Verify scroll follows selection with proper margins
- [ ] Test Enter key triggers selection callback
- [ ] Verify Ctrl+C exits the application

Closes #7
Closes #25

🤖 Generated with [Claude Code](https://claude.ai/claude-code)