### PR TITLE
feat(screen): Timeline screen with For You/Following tabs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,27 @@ bun run start      # Run the TUI
 bun run typecheck  # TypeScript type checking
 bun run lint       # Check linting (oxlint + oxfmt)
 bun run lint:fix   # Auto-fix lint issues
+bun run test       # Run all tests (IMPORTANT: use this, not `bun test`)
+```
+
+### Testing
+
+**Always use `bun run test`**, not `bun test` directly.
+
+The test suite uses `mock.module()` for module mocking in `check.test.ts`, which pollutes the module cache across test files. The npm script runs tests in isolated batches to prevent this:
+
+```bash
+# Correct - runs tests in isolation
+bun run test
+
+# WRONG - will cause 130+ test failures due to mock pollution
+bun test
+```
+
+For specific test files:
+```bash
+bun test src/api/client.test.ts          # Single file works fine
+bun test -t "getTweet"                    # Filter by test name
 ```
 
 ## Architecture

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -9,10 +9,16 @@ export function Footer() {
         flexDirection: "row",
       }}
     >
-      <text fg="#ffffff">q</text>
-      <text fg="#666666"> quit </text>
+      <text fg="#ffffff">j/k</text>
+      <text fg="#666666"> nav </text>
+      <text fg="#ffffff">1/2</text>
+      <text fg="#666666"> tabs </text>
+      <text fg="#ffffff">r</text>
+      <text fg="#666666"> refresh </text>
       <text fg="#ffffff">Tab</text>
-      <text fg="#666666"> switch view</text>
+      <text fg="#666666"> view </text>
+      <text fg="#ffffff">q</text>
+      <text fg="#666666"> quit</text>
     </box>
   );
 }

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -24,47 +24,37 @@ export function PostCard({ post, isSelected, id }: PostCardProps) {
     <box
       id={id}
       style={{
-        flexDirection: "row",
+        flexDirection: "column",
         marginBottom: 1,
+        paddingLeft: 1,
+        paddingRight: 1,
+        paddingTop: 1,
         backgroundColor: isSelected ? SELECTED_BG : undefined,
       }}
     >
-      {/* Selection indicator */}
-      <box style={{ width: 2, flexShrink: 0 }}>
+      {/* Author line with selection indicator */}
+      <box style={{ flexDirection: "row" }}>
         <text fg={X_BLUE}>{isSelected ? "> " : "  "}</text>
+        <text fg={X_BLUE}>@{post.author.username}</text>
+        <text fg="#666666">
+          {" "}
+          · {post.author.name}
+          {timeAgo ? ` · ${timeAgo}` : ""}
+        </text>
       </box>
 
-      {/* Post content */}
-      <box
-        style={{
-          flexDirection: "column",
-          flexGrow: 1,
-          padding: 1,
-        }}
-      >
-        {/* Author line */}
-        <box style={{ flexDirection: "row" }}>
-          <text fg={X_BLUE}>@{post.author.username}</text>
-          <text fg="#666666">
-            {" "}
-            · {post.author.name}
-            {timeAgo ? ` · ${timeAgo}` : ""}
-          </text>
-        </box>
+      {/* Post text */}
+      <box style={{ marginTop: 1, paddingLeft: 2 }}>
+        <text fg="#ffffff">{displayText}</text>
+      </box>
 
-        {/* Post text */}
-        <box style={{ marginTop: 1 }}>
-          <text fg="#ffffff">{displayText}</text>
-        </box>
-
-        {/* Stats line */}
-        <box style={{ flexDirection: "row", marginTop: 1 }}>
-          <text fg="#888888">
-            {formatCount(post.replyCount)} replies {"  "}
-            {formatCount(post.retweetCount)} reposts {"  "}
-            {formatCount(post.likeCount)} likes
-          </text>
-        </box>
+      {/* Stats line */}
+      <box style={{ flexDirection: "row", marginTop: 1, paddingLeft: 2 }}>
+        <text fg="#888888">
+          {formatCount(post.replyCount)} replies {"  "}
+          {formatCount(post.retweetCount)} reposts {"  "}
+          {formatCount(post.likeCount)} likes
+        </text>
       </box>
     </box>
   );

--- a/src/hooks/useTimeline.ts
+++ b/src/hooks/useTimeline.ts
@@ -1,0 +1,88 @@
+/**
+ * useTimeline - Hook for fetching and managing timeline data
+ * Supports switching between For You (algorithmic) and Following (chronological) feeds
+ */
+
+import { useState, useEffect, useCallback } from "react";
+
+import type { TwitterClient } from "@/api/client";
+import type { TweetData } from "@/api/types";
+
+export type TimelineTab = "for_you" | "following";
+
+export interface UseTimelineOptions {
+  client: TwitterClient;
+  initialTab?: TimelineTab;
+}
+
+export interface UseTimelineResult {
+  /** Currently active tab */
+  tab: TimelineTab;
+  /** Switch to a different tab */
+  setTab: (tab: TimelineTab) => void;
+  /** List of posts for current tab */
+  posts: TweetData[];
+  /** Whether data is currently loading */
+  loading: boolean;
+  /** Error message if fetch failed */
+  error: string | null;
+  /** Refresh the current timeline */
+  refresh: () => void;
+}
+
+export function useTimeline({
+  client,
+  initialTab = "for_you",
+}: UseTimelineOptions): UseTimelineResult {
+  const [tab, setTabInternal] = useState<TimelineTab>(initialTab);
+  const [posts, setPosts] = useState<TweetData[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshCounter, setRefreshCounter] = useState(0);
+
+  const fetchTimeline = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    const result =
+      tab === "for_you"
+        ? await client.getHomeTimeline(30)
+        : await client.getHomeLatestTimeline(30);
+
+    if (result.success) {
+      setPosts(result.tweets);
+    } else {
+      setError(result.error);
+    }
+
+    setLoading(false);
+  }, [client, tab]);
+
+  // Fetch when tab changes or refresh is triggered
+  useEffect(() => {
+    fetchTimeline();
+  }, [fetchTimeline, refreshCounter]);
+
+  const setTab = useCallback((newTab: TimelineTab) => {
+    setTabInternal((prev) => {
+      if (prev !== newTab) {
+        // Clear posts when switching tabs for smoother transition
+        setPosts([]);
+      }
+      return newTab;
+    });
+  }, []);
+
+  const refresh = useCallback(() => {
+    setRefreshCounter((prev) => prev + 1);
+  }, []);
+
+  return {
+    tab,
+    setTab,
+    posts,
+    loading,
+    error,
+    refresh,
+  };
+}

--- a/src/screens/TimelineScreen.tsx
+++ b/src/screens/TimelineScreen.tsx
@@ -1,13 +1,15 @@
 /**
- * TimelineScreen - Displays the user's timeline
+ * TimelineScreen - Displays the user's timeline with For You / Following tabs
  */
 
-import { useState, useEffect } from "react";
+import { useKeyboard } from "@opentui/react";
+import { useEffect } from "react";
 
 import type { TwitterClient } from "@/api/client";
 import type { TweetData } from "@/api/types";
 
 import { PostList } from "@/components/PostList";
+import { useTimeline, type TimelineTab } from "@/hooks/useTimeline";
 
 interface TimelineScreenProps {
   client: TwitterClient;
@@ -15,63 +17,114 @@ interface TimelineScreenProps {
   onPostCountChange?: (count: number) => void;
 }
 
+interface TabBarProps {
+  activeTab: TimelineTab;
+}
+
+function TabBar({ activeTab }: TabBarProps) {
+  return (
+    <box
+      style={{
+        flexShrink: 0,
+        paddingLeft: 1,
+        paddingRight: 1,
+        paddingBottom: 1,
+        flexDirection: "row",
+      }}
+    >
+      <text fg={activeTab === "for_you" ? "#1DA1F2" : "#666666"}>
+        {activeTab === "for_you" ? (
+          <b>[1] For You</b>
+        ) : (
+          " 1  For You"
+        )}
+      </text>
+      <text fg="#666666"> | </text>
+      <text fg={activeTab === "following" ? "#1DA1F2" : "#666666"}>
+        {activeTab === "following" ? (
+          <b>[2] Following</b>
+        ) : (
+          " 2  Following"
+        )}
+      </text>
+    </box>
+  );
+}
+
 export function TimelineScreen({
   client,
   focused = false,
   onPostCountChange,
 }: TimelineScreenProps) {
-  const [posts, setPosts] = useState<TweetData[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const { tab, setTab, posts, loading, error, refresh } = useTimeline({
+    client,
+  });
 
   // Report post count to parent
   useEffect(() => {
     onPostCountChange?.(posts.length);
   }, [posts.length, onPostCountChange]);
 
-  useEffect(() => {
-    async function fetchTimeline() {
-      setLoading(true);
-      setError(null);
+  // Handle keyboard shortcuts for tab switching and refresh
+  useKeyboard((key) => {
+    if (!focused) return;
 
-      const result = await client.getHomeLatestTimeline(30);
-
-      if (result.success) {
-        setPosts(result.tweets);
-      } else {
-        setError(result.error);
-      }
-
-      setLoading(false);
+    switch (key.name) {
+      case "1":
+        setTab("for_you");
+        break;
+      case "2":
+        setTab("following");
+        break;
+      case "r":
+        refresh();
+        break;
     }
-
-    fetchTimeline();
-  }, [client]);
+  });
 
   if (loading) {
     return (
-      <box style={{ padding: 2 }}>
-        <text fg="#888888">Loading timeline...</text>
+      <box style={{ flexDirection: "column", height: "100%" }}>
+        <TabBar activeTab={tab} />
+        <box style={{ padding: 2, flexGrow: 1 }}>
+          <text fg="#888888">Loading timeline...</text>
+        </box>
       </box>
     );
   }
 
   if (error) {
     return (
-      <box style={{ padding: 2 }}>
-        <text fg="#ff6666">Error: {error}</text>
+      <box style={{ flexDirection: "column", height: "100%" }}>
+        <TabBar activeTab={tab} />
+        <box style={{ padding: 2, flexGrow: 1 }}>
+          <text fg="#ff6666">Error: {error}</text>
+        </box>
+      </box>
+    );
+  }
+
+  if (posts.length === 0) {
+    return (
+      <box style={{ flexDirection: "column", height: "100%" }}>
+        <TabBar activeTab={tab} />
+        <box style={{ padding: 2, flexGrow: 1 }}>
+          <text fg="#888888">No posts to display. Press r to refresh.</text>
+        </box>
       </box>
     );
   }
 
   return (
-    <PostList
-      posts={posts}
-      focused={focused}
-      onPostSelect={(_post) => {
-        // Future: expand post detail view
-        // For now, we just highlight - Enter does nothing visible yet
-      }}
-    />
+    <box style={{ flexDirection: "column", height: "100%" }}>
+      <TabBar activeTab={tab} />
+      <PostList
+        posts={posts}
+        focused={focused}
+        onPostSelect={(_post: TweetData) => {
+          // Future: expand post detail view
+        }}
+      />
+    </box>
   );
 }


### PR DESCRIPTION
## Summary
- Implements timeline screen with For You (algorithmic) and Following (chronological) feed tabs
- Users can switch between tabs with 1/2 keys and refresh with r
- Optimized PostCard layout to save vertical space by merging selector with author line

## Changes
- **useTimeline.ts**: New hook for managing timeline state and tab switching
- **TimelineScreen.tsx**: Tab UI with keyboard shortcuts (1/2/r)
- **PostCard.tsx**: Layout refactor - selector now inline with author info
- **Footer.tsx**: Updated to show new keybindings
- **CLAUDE.md**: Added testing documentation

## Addresses
Closes #8

🤖 Generated with Claude Code