### PR TITLE
feat(media): Quick Look preview, download, and media indicators

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -30,6 +30,36 @@ export interface TweetAuthor {
 }
 
 /**
+ * Media item attached to a tweet (photo, video, or animated GIF)
+ */
+export interface MediaItem {
+  /** Unique media ID */
+  id: string;
+  /** Media type: photo, video, or animated_gif */
+  type: "photo" | "video" | "animated_gif";
+  /** Direct URL to the media (for photos, this is the display URL) */
+  url: string;
+  /** Width in pixels */
+  width?: number;
+  /** Height in pixels */
+  height?: number;
+  /** Video variants (only for video/animated_gif types) */
+  videoVariants?: VideoVariant[];
+}
+
+/**
+ * Video variant with quality/format information
+ */
+export interface VideoVariant {
+  /** Bitrate in bits per second (higher = better quality) */
+  bitrate?: number;
+  /** MIME type (e.g., "video/mp4", "application/x-mpegURL") */
+  contentType: string;
+  /** Direct URL to the video variant */
+  url: string;
+}
+
+/**
  * Core tweet data structure
  */
 export interface TweetData {
@@ -45,6 +75,8 @@ export interface TweetData {
   inReplyToStatusId?: string;
   /** Quoted tweet data (recursive, depth controlled by quoteDepth option) */
   quotedTweet?: TweetData;
+  /** Media attachments (photos, videos, GIFs) */
+  media?: MediaItem[];
 }
 
 /**
@@ -115,6 +147,24 @@ export interface GraphqlTweetResult {
     favorite_count?: number;
     conversation_id_str?: string;
     in_reply_to_status_id_str?: string | null;
+    extended_entities?: {
+      media?: Array<{
+        id_str?: string;
+        type: "photo" | "video" | "animated_gif";
+        media_url_https: string;
+        original_info?: {
+          width?: number;
+          height?: number;
+        };
+        video_info?: {
+          variants: Array<{
+            bitrate?: number;
+            content_type: string;
+            url: string;
+          }>;
+        };
+      }>;
+    };
   };
   core?: {
     user_results?: {

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -11,6 +11,8 @@ import { QuotedPostCard } from "./QuotedPostCard";
 const MAX_TEXT_LINES = 3;
 const SELECTED_BG = "#1a1a2e";
 const X_BLUE = "#1DA1F2";
+const COLOR_SUCCESS = "#17BF63";
+const COLOR_WARNING = "#FFAD1F";
 
 interface PostCardProps {
   post: TweetData;
@@ -21,6 +23,7 @@ interface PostCardProps {
 export function PostCard({ post, isSelected, id }: PostCardProps) {
   const displayText = truncateText(post.text, MAX_TEXT_LINES);
   const timeAgo = formatRelativeTime(post.createdAt);
+  const hasMedia = post.media && post.media.length > 0;
 
   return (
     <box
@@ -65,6 +68,37 @@ export function PostCard({ post, isSelected, id }: PostCardProps) {
           {formatCount(post.likeCount)} likes
         </text>
       </box>
+
+      {/* Media indicators - colored labels */}
+      {hasMedia && (
+        <box style={{ flexDirection: "row", marginTop: 1, paddingLeft: 2 }}>
+          {post.media?.map((item) => {
+            const dims =
+              item.width && item.height
+                ? ` (${item.width}x${item.height})`
+                : "";
+            const typeLabel =
+              item.type === "photo"
+                ? "Image"
+                : item.type === "video"
+                  ? "Video"
+                  : "GIF";
+            const typeColor =
+              item.type === "photo"
+                ? X_BLUE
+                : item.type === "video"
+                  ? COLOR_WARNING
+                  : COLOR_SUCCESS;
+            return (
+              <text key={item.id} fg={typeColor}>
+                • {typeLabel}
+                {dims}
+                {"  "}
+              </text>
+            );
+          })}
+        </box>
+      )}
     </box>
   );
 }

--- a/src/lib/media.ts
+++ b/src/lib/media.ts
@@ -1,2 +1,181 @@
-// Media handling utilities: Quick Look, download
-// TODO: Implement in #11
+/**
+ * Media handling utilities: Quick Look preview, download, and browser open
+ */
+
+import { spawn } from "node:child_process";
+import { mkdir, writeFile, unlink } from "node:fs/promises";
+import { homedir, platform, tmpdir } from "node:os";
+import { join, extname } from "node:path";
+
+import type { MediaItem } from "@/api/types";
+
+/**
+ * Default headers for fetching media from Twitter CDN
+ * Helps avoid 403 errors from hotlinking protection
+ */
+const MEDIA_FETCH_HEADERS = {
+  "User-Agent":
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+  Referer: "https://x.com/",
+  Accept: "image/webp,image/apng,image/*,*/*;q=0.8",
+};
+
+/**
+ * Result type for media operations
+ */
+export type MediaResult =
+  | { success: true; message: string }
+  | { success: false; error: string };
+
+/**
+ * Get the best video URL (highest quality MP4)
+ */
+function getBestVideoUrl(media: MediaItem): string {
+  if (media.videoVariants && media.videoVariants.length > 0) {
+    // videoVariants are already sorted by bitrate descending in extractMedia
+    return media.videoVariants[0]?.url ?? media.url;
+  }
+  return media.url;
+}
+
+/**
+ * Get file extension from URL or media type
+ */
+function getExtension(media: MediaItem): string {
+  if (media.type === "photo") {
+    const urlExt = extname(media.url.split("?")[0] ?? "");
+    return urlExt || ".jpg";
+  }
+  // Videos and GIFs are MP4
+  return ".mp4";
+}
+
+/**
+ * Open a URL in the default browser
+ */
+async function openInBrowser(url: string): Promise<void> {
+  const os = platform();
+  const cmd = os === "darwin" ? "open" : os === "win32" ? "start" : "xdg-open";
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, [url], {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.on("error", reject);
+    child.unref();
+    // Give it a moment to launch
+    setTimeout(resolve, 100);
+  });
+}
+
+/**
+ * Preview media using Quick Look (macOS) or browser fallback
+ *
+ * - Photos on macOS: Download to temp, open with qlmanage -p
+ * - Photos on Linux: Open URL with xdg-open (opens in browser)
+ * - Videos/GIFs: Always open in browser
+ */
+export async function previewMedia(
+  media: MediaItem,
+  tweetId: string,
+  index: number
+): Promise<MediaResult> {
+  const os = platform();
+
+  // Videos and GIFs always open in browser
+  if (media.type === "video" || media.type === "animated_gif") {
+    const videoUrl = getBestVideoUrl(media);
+    try {
+      await openInBrowser(videoUrl);
+      return { success: true, message: "Opened video in browser" };
+    } catch {
+      return { success: false, error: "Failed to open browser" };
+    }
+  }
+
+  // Photos on macOS: Quick Look
+  if (os === "darwin") {
+    try {
+      // Download to temp file
+      const ext = getExtension(media);
+      const tempPath = join(tmpdir(), `xfeed_${tweetId}_${index}${ext}`);
+
+      const response = await fetch(media.url, { headers: MEDIA_FETCH_HEADERS });
+      if (!response.ok) {
+        return { success: false, error: `Download failed: ${response.status}` };
+      }
+
+      const buffer = await response.arrayBuffer();
+      await writeFile(tempPath, Buffer.from(buffer));
+
+      // Open with Quick Look
+      return new Promise((resolve) => {
+        const child = spawn("qlmanage", ["-p", tempPath], {
+          stdio: "ignore",
+        });
+
+        child.on("close", () => {
+          // Clean up temp file after Quick Look closes
+          unlink(tempPath).catch(() => {});
+          resolve({ success: true, message: "Closed Quick Look" });
+        });
+
+        child.on("error", () => {
+          resolve({ success: false, error: "Failed to open Quick Look" });
+        });
+      });
+    } catch {
+      return { success: false, error: "Failed to preview image" };
+    }
+  }
+
+  // Linux/other: Open URL in browser
+  try {
+    await openInBrowser(media.url);
+    return { success: true, message: "Opened image in browser" };
+  } catch {
+    return { success: false, error: "Failed to open browser" };
+  }
+}
+
+/**
+ * Download media to ~/Downloads/xfeed/
+ *
+ * Filename format: {tweet_id}_{index}.{ext}
+ */
+export async function downloadMedia(
+  media: MediaItem,
+  tweetId: string,
+  index: number
+): Promise<MediaResult> {
+  const downloadDir = join(homedir(), "Downloads", "xfeed");
+  const ext = getExtension(media);
+  const filename = `${tweetId}_${index}${ext}`;
+  const filepath = join(downloadDir, filename);
+
+  try {
+    // Ensure download directory exists
+    await mkdir(downloadDir, { recursive: true });
+
+    // Get the best URL (for videos, get highest quality)
+    const url =
+      media.type === "video" || media.type === "animated_gif"
+        ? getBestVideoUrl(media)
+        : media.url;
+
+    // Download the file
+    const response = await fetch(url, { headers: MEDIA_FETCH_HEADERS });
+    if (!response.ok) {
+      return { success: false, error: `Download failed: ${response.status}` };
+    }
+
+    const buffer = await response.arrayBuffer();
+    await writeFile(filepath, Buffer.from(buffer));
+
+    return { success: true, message: `Saved to ~/Downloads/xfeed/${filename}` };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return { success: false, error: `Download failed: ${message}` };
+  }
+}


### PR DESCRIPTION
## Summary

Implements media handling for issue #12 with Quick Look preview on macOS, browser open for videos, download-to-disk functionality, and colored media type indicators in both timeline and detail views.

## Features

- **Preview**: `i` key opens Quick Look for images (macOS), browser for videos
- **Download**: `d` key saves media to `~/Downloads/xfeed/` with format `{tweet_id}_{index}.{ext}`
- **Navigation**: `[`/`]` keys cycle through multiple media items
- **Display**: Colored labels (blue=photo, orange=video, green=GIF) with dimensions in timeline and detail view
- **Headers**: Adds User-Agent/Referer headers to prevent 403 errors from Twitter CDN

## Implementation

- Extract media from GraphQL `extended_entities.media` in client
- Media types and video variant structures in types.ts
- Cross-platform support: Quick Look (macOS), xdg-open (Linux), browser fallback
- Status messages show operation feedback (auto-clear after 3s)

Fixes #12.