### PR TITLE
ci: Enforce issue references in pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,23 @@ jobs:
           bun-version: latest
       - run: bun install --frozen-lockfile
       - run: bun run lint
+
+  pr-issue-check:
+    name: PR links issue
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Check for issue reference
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          # Match patterns: #123, Fixes #123, Closes #456, Resolves #789
+          PATTERN='#[0-9]+'
+
+          if echo "$PR_TITLE $PR_BODY" | grep -qE "$PATTERN"; then
+            echo "✅ Issue reference found"
+          else
+            echo "::error::PR must reference an issue (e.g., '#123' or 'Fixes #123')"
+            exit 1
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,10 @@ bun test src/api/client.test.ts          # Single file works fine
 bun test -t "getTweet"                    # Filter by test name
 ```
 
+### Pull Requests
+
+PRs must reference a GitHub issue (e.g., `#123` or `Fixes #123`) in the title or body. CI will fail without an issue reference.
+
 ## Architecture
 
 ### Layers


### PR DESCRIPTION
## Summary
Add a CI check that requires all PRs to reference a GitHub issue by including patterns like `#123`, `Fixes #123`, or `Closes #123` in the PR title or body. This check is now a required status check on the main branch.

## Test plan
- Create a test PR without an issue reference and verify CI fails
- Create a test PR with an issue reference and verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)