### PR TITLE
feat(links): Add link parsing, rendering, and browser integration

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -18,6 +18,7 @@ import type {
   TweetResult,
   TwitterClientOptions,
   UploadMediaResult,
+  UrlEntity,
 } from "./types";
 
 import {
@@ -636,6 +637,93 @@ export class TwitterClient {
     });
   }
 
+  /**
+   * Check if a URL points to media (should be hidden from tweet text)
+   */
+  private isMediaUrl(expandedUrl: string): boolean {
+    const lower = expandedUrl.toLowerCase();
+    return (
+      lower.includes("pic.twitter.com") ||
+      lower.includes("video.twimg.com") ||
+      lower.includes("/photo/") ||
+      lower.includes("/video/")
+    );
+  }
+
+  /**
+   * Extract URL entities from legacy.entities.urls
+   * Filters out media URLs (t.co links that point to pic.twitter.com)
+   */
+  private extractUrls(result: GraphqlTweetResult): UrlEntity[] | undefined {
+    const rawUrls = result.legacy?.entities?.urls;
+    if (!rawUrls || rawUrls.length === 0) {
+      return undefined;
+    }
+
+    // Filter out media URLs (pic.twitter.com, video.twimg.com)
+    const urls = rawUrls
+      .filter((u) => !this.isMediaUrl(u.expanded_url))
+      .map((u) => ({
+        url: u.url,
+        expandedUrl: u.expanded_url,
+        displayUrl: u.display_url,
+        indices: u.indices,
+      }));
+
+    return urls.length > 0 ? urls : undefined;
+  }
+
+  /**
+   * Strip media URLs from tweet text
+   * Twitter includes t.co links in full_text for media, but hides them in UI
+   * Media URLs can be in entities.urls (pointing to pic.twitter.com) OR entities.media
+   */
+  private stripMediaUrlsFromText(
+    text: string,
+    result: GraphqlTweetResult
+  ): string {
+    const allIndices: [number, number][] = [];
+
+    // Check entities.urls for URLs pointing to media (pic.twitter.com, etc)
+    const rawUrls = result.legacy?.entities?.urls;
+    if (rawUrls) {
+      for (const u of rawUrls) {
+        if (this.isMediaUrl(u.expanded_url)) {
+          allIndices.push(u.indices);
+        }
+      }
+    }
+
+    // Check entities.media for direct media t.co URLs (videos, images)
+    const mediaEntities = result.legacy?.entities?.media;
+    if (mediaEntities) {
+      for (const m of mediaEntities) {
+        allIndices.push(m.indices);
+      }
+    }
+
+    if (allIndices.length === 0) {
+      return text;
+    }
+
+    // Sort by index descending to remove from end first (preserves earlier indices)
+    allIndices.sort((a, b) => b[0] - a[0]);
+
+    // Remove each media URL from text (working backwards to preserve indices)
+    let result_text = text;
+    for (const [start, end] of allIndices) {
+      // Also trim trailing whitespace before the URL
+      let trimStart = start;
+      while (trimStart > 0 && result_text[trimStart - 1] === " ") {
+        trimStart--;
+      }
+      result_text =
+        result_text.substring(0, trimStart) + result_text.substring(end);
+    }
+
+    return result_text.trim();
+  }
+
   private mapTweetResult(
     result: GraphqlTweetResult | undefined,
     quoteDepth: number
@@ -650,10 +738,12 @@ export class TwitterClient {
       return undefined;
     }
 
-    const text = this.extractTweetText(result);
-    if (!text) {
+    const rawText = this.extractTweetText(result);
+    if (!rawText) {
       return undefined;
     }
+    // Strip media URLs (t.co links to pic.twitter.com etc) from displayed text
+    const text = this.stripMediaUrlsFromText(rawText, result);
 
     // Handle quoted tweets recursively
     let quotedTweet: TweetData | undefined;
@@ -682,6 +772,7 @@ export class TwitterClient {
       authorId: userId,
       quotedTweet,
       media: this.extractMedia(result),
+      urls: this.extractUrls(result),
     };
   }
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -60,6 +60,20 @@ export interface VideoVariant {
 }
 
 /**
+ * URL entity from tweet text
+ */
+export interface UrlEntity {
+  /** Shortened t.co URL as it appears in tweet text */
+  url: string;
+  /** Full expanded URL */
+  expandedUrl: string;
+  /** Display-friendly URL (truncated, no protocol) */
+  displayUrl: string;
+  /** Character indices in tweet text [start, end] */
+  indices: [number, number];
+}
+
+/**
  * Core tweet data structure
  */
 export interface TweetData {
@@ -77,6 +91,8 @@ export interface TweetData {
   quotedTweet?: TweetData;
   /** Media attachments (photos, videos, GIFs) */
   media?: MediaItem[];
+  /** URL entities parsed from tweet text */
+  urls?: UrlEntity[];
 }
 
 /**
@@ -178,6 +194,18 @@ export interface GraphqlTweetResult {
     favorite_count?: number;
     conversation_id_str?: string;
     in_reply_to_status_id_str?: string | null;
+    entities?: {
+      urls?: Array<{
+        url: string;
+        expanded_url: string;
+        display_url: string;
+        indices: [number, number];
+      }>;
+      media?: Array<{
+        url: string;
+        indices: [number, number];
+      }>;
+    };
     extended_entities?: {
       media?: Array<{
         id_str?: string;

--- a/src/lib/media.ts
+++ b/src/lib/media.ts
@@ -7,7 +7,7 @@ import { mkdir, writeFile, unlink } from "node:fs/promises";
 import { homedir, platform, tmpdir } from "node:os";
 import { join, extname } from "node:path";
 
-import type { MediaItem } from "@/api/types";
+import type { MediaItem, UrlEntity } from "@/api/types";
 
 /**
  * Default headers for fetching media from Twitter CDN
@@ -26,6 +26,84 @@ const MEDIA_FETCH_HEADERS = {
 export type MediaResult =
   | { success: true; message: string }
   | { success: false; error: string };
+
+/**
+ * Check if a URL is safe to fetch (not targeting internal/private resources)
+ * Prevents SSRF attacks
+ */
+function isUrlSafeToFetch(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+
+    // Only allow http/https schemes
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return false;
+    }
+
+    const hostname = parsed.hostname.toLowerCase();
+
+    // Block localhost variants
+    if (
+      hostname === "localhost" ||
+      hostname === "127.0.0.1" ||
+      hostname === "0.0.0.0" ||
+      hostname === "::1" ||
+      hostname.endsWith(".localhost")
+    ) {
+      return false;
+    }
+
+    // Block private IP ranges (RFC 1918) and link-local
+    const ipv4Match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(
+      hostname
+    );
+    if (ipv4Match) {
+      const [, a, b] = ipv4Match.map(Number);
+      // 10.x.x.x (Class A private)
+      if (a === 10) return false;
+      // 172.16-31.x.x (Class B private)
+      if (a === 172 && b !== undefined && b >= 16 && b <= 31) return false;
+      // 192.168.x.x (Class C private)
+      if (a === 192 && b === 168) return false;
+      // 127.x.x.x (loopback)
+      if (a === 127) return false;
+      // 169.254.x.x (link-local, includes cloud metadata endpoint)
+      if (a === 169 && b === 254) return false;
+      // 0.x.x.x
+      if (a === 0) return false;
+    }
+
+    // Block common internal hostnames
+    const internalPatterns = [
+      /^internal\./i,
+      /^intranet\./i,
+      /^private\./i,
+      /\.internal$/i,
+      /\.local$/i,
+      /\.corp$/i,
+    ];
+    if (internalPatterns.some((pattern) => pattern.test(hostname))) {
+      return false;
+    }
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if a URL scheme is safe to open in browser
+ */
+function isUrlSafeToOpen(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    // Only allow http/https - block file://, javascript:, data:, etc.
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Get the best video URL (highest quality MP4)
@@ -52,8 +130,14 @@ function getExtension(media: MediaItem): string {
 
 /**
  * Open a URL in the default browser
+ * Only allows http/https URLs for security (blocks file://, javascript:, etc.)
  */
-async function openInBrowser(url: string): Promise<void> {
+export async function openInBrowser(url: string): Promise<void> {
+  // Security: Validate URL scheme to prevent opening local files or executing scripts
+  if (!isUrlSafeToOpen(url)) {
+    throw new Error("URL scheme not allowed");
+  }
+
   const os = platform();
   const cmd = os === "darwin" ? "open" : os === "win32" ? "start" : "xdg-open";
 
@@ -177,5 +261,149 @@ export async function downloadMedia(
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";
     return { success: false, error: `Download failed: ${message}` };
+  }
+}
+
+/**
+ * Link metadata from HEAD/GET request
+ */
+export interface LinkMetadata {
+  /** Page title if available */
+  title?: string;
+  /** Domain extracted from URL */
+  domain: string;
+  /** Content type from headers */
+  contentType?: string;
+  /** Whether the link is reachable */
+  reachable: boolean;
+}
+
+/**
+ * Extract domain from URL
+ */
+function extractDomain(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return parsed.hostname.replace(/^www\./, "");
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Fetch metadata for a URL using HEAD request with GET fallback
+ * Returns domain and title (if available from HTML)
+ */
+export async function fetchLinkMetadata(
+  urlEntity: UrlEntity
+): Promise<LinkMetadata> {
+  const url = urlEntity.expandedUrl;
+  const domain = extractDomain(url);
+
+  // Security: Block requests to internal/private resources (SSRF prevention)
+  if (!isUrlSafeToFetch(url)) {
+    return { domain, reachable: false };
+  }
+
+  try {
+    // Try HEAD first for quick metadata
+    // Note: redirect: "manual" to prevent redirect-based SSRF bypass
+    const headResponse = await fetch(url, {
+      method: "HEAD",
+      headers: {
+        "User-Agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+        Accept: "text/html,application/xhtml+xml,*/*",
+      },
+      redirect: "manual",
+    });
+
+    // Handle redirects manually - check if redirect target is also safe
+    if (headResponse.status >= 300 && headResponse.status < 400) {
+      const location = headResponse.headers.get("location");
+      if (location) {
+        // Resolve relative URLs
+        const redirectUrl = new URL(location, url).href;
+        if (!isUrlSafeToFetch(redirectUrl)) {
+          return { domain, reachable: false };
+        }
+        // Follow one redirect if safe
+        const redirectResponse = await fetch(redirectUrl, {
+          method: "HEAD",
+          headers: {
+            "User-Agent":
+              "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+            Accept: "text/html,application/xhtml+xml,*/*",
+          },
+          redirect: "manual",
+        });
+        if (!redirectResponse.ok && redirectResponse.status < 300) {
+          return { domain, reachable: false };
+        }
+      }
+    }
+
+    if (!headResponse.ok) {
+      return { domain, reachable: false };
+    }
+
+    const contentType = headResponse.headers.get("content-type") ?? undefined;
+
+    // If HTML, try to fetch title with a GET request
+    if (contentType?.includes("text/html")) {
+      try {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 5000);
+
+        const getResponse = await fetch(url, {
+          method: "GET",
+          headers: {
+            "User-Agent":
+              "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+            Accept: "text/html",
+            // Disable compression to avoid ZlibError with partial content
+            "Accept-Encoding": "identity",
+          },
+          signal: controller.signal,
+        });
+
+        clearTimeout(timeout);
+
+        if (getResponse.ok) {
+          // Only read first 16KB to find title quickly
+          const reader = getResponse.body?.getReader();
+          if (reader) {
+            let html = "";
+            let bytesRead = 0;
+            const maxBytes = 16384;
+
+            while (bytesRead < maxBytes) {
+              const { done, value } = await reader.read();
+              if (done) break;
+              html += new TextDecoder().decode(value);
+              bytesRead += value.length;
+
+              // Check if we found the title already
+              const titleMatch = /<title[^>]*>([^<]+)<\/title>/i.exec(html);
+              if (titleMatch?.[1]) {
+                reader.cancel();
+                const title = titleMatch[1]
+                  .trim()
+                  .replace(/\s+/g, " ")
+                  .slice(0, 100);
+                return { domain, contentType, title, reachable: true };
+              }
+            }
+            reader.cancel();
+          }
+        }
+      } catch {
+        // Ignore GET errors, still return HEAD success
+      }
+    }
+
+    return { domain, contentType, reachable: true };
+  } catch {
+    return { domain, reachable: false };
   }
 }


### PR DESCRIPTION
## Summary

Implement complete link support in post detail view with URL extraction, metadata fetching, navigation, and secure browser integration. Resolves issues #38 and #43.

## Features

- Parse and extract URL entities from tweets (filters media URLs to match Twitter's behavior)
- Display links with page title metadata fetched via HEAD/GET requests
- Navigate between links with `,` and `.` keys
- Open selected link in browser with `o` key, falls back to opening tweet if no link selected
- Comprehensive SSRF protection blocking internal/private IP ranges and dangerous redirects

## Testing

All 212 tests pass, including new link handling and existing functionality.

Fixes #38 #43