### PR TITLE
feat: extract like/bookmark state and enable list view actions (#56)

### DIFF
--- a/docs/api-response-structure.md
+++ b/docs/api-response-structure.md
@@ -26,10 +26,10 @@ interface GraphqlTweetResult {
     conversation_id_str?: string;
     in_reply_to_status_id_str?: string | null;
 
-    // User interaction state (NOT EXTRACTED)
-    favorited?: boolean;         // Is liked by current user
-    bookmarked?: boolean;        // Is bookmarked by current user
-    retweeted?: boolean;         // Is retweeted by current user
+    // User interaction state
+    favorited?: boolean;         // Is liked by current user (EXTRACTED)
+    bookmarked?: boolean;        // Is bookmarked by current user (EXTRACTED)
+    retweeted?: boolean;         // Is retweeted by current user (NOT EXTRACTED)
 
     // Media (NOT EXTRACTED)
     extended_entities?: {
@@ -123,6 +123,8 @@ Currently extracted into `TweetData`:
 | `author.name` | `core.user_results.result.legacy.name` | Yes |
 | `authorId` | `core.user_results.result.rest_id` | Yes |
 | `quotedTweet` | `quoted_status_result.result` (recursive) | Yes |
+| `favorited` | `legacy.favorited` | Yes |
+| `bookmarked` | `legacy.bookmarked` | Yes |
 
 ## Not Yet Extracted
 
@@ -131,7 +133,7 @@ Could be added in future:
 - `views.count` - View count
 - `legacy.quote_count` - Quote count
 - `legacy.bookmark_count` - Bookmark count
-- `legacy.favorited` / `bookmarked` / `retweeted` - User interaction state
+- `legacy.retweeted` - User retweet state
 - `legacy.extended_entities.media` - Photos, videos, GIFs
 - `legacy.entities` - URLs, mentions, hashtags
 - `core.user_results.result.legacy.profile_image_url_https` - Avatar

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -829,6 +829,8 @@ export class TwitterClient {
       quotedTweet,
       media: this.extractMedia(result),
       urls: this.extractUrls(result),
+      favorited: result.legacy?.favorited ?? false,
+      bookmarked: result.legacy?.bookmarked ?? false,
     };
   }
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -93,6 +93,10 @@ export interface TweetData {
   media?: MediaItem[];
   /** URL entities parsed from tweet text */
   urls?: UrlEntity[];
+  /** Whether the tweet is liked by the current user */
+  favorited?: boolean;
+  /** Whether the tweet is bookmarked by the current user */
+  bookmarked?: boolean;
 }
 
 /**
@@ -194,6 +198,8 @@ export interface GraphqlTweetResult {
     favorite_count?: number;
     conversation_id_str?: string;
     in_reply_to_status_id_str?: string | null;
+    favorited?: boolean;
+    bookmarked?: boolean;
     entities?: {
       urls?: Array<{
         url: string;

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -38,7 +38,7 @@ export function App({ client, user: _user }: AppProps) {
   const [actionMessage, setActionMessage] = useState<string | null>(null);
 
   // Actions hook for like/bookmark mutations
-  const { toggleLike, toggleBookmark, getState } = useActions({
+  const { toggleLike, toggleBookmark, getState, initState } = useActions({
     client,
     onError: (error) => setActionMessage(`Error: ${error}`),
     onSuccess: (message) => setActionMessage(message),
@@ -99,9 +99,10 @@ export function App({ client, user: _user }: AppProps) {
   const handlePostSelect = useCallback(
     (post: TweetData) => {
       setSelectedPost(post);
+      initState(post.id, post.favorited ?? false, post.bookmarked ?? false);
       navigate("post-detail");
     },
-    [navigate]
+    [navigate, initState]
   );
 
   // Return from post detail to previous view
@@ -132,9 +133,10 @@ export function App({ client, user: _user }: AppProps) {
   const handlePostSelectFromProfile = useCallback(
     (post: TweetData) => {
       setSelectedPost(post);
+      initState(post.id, post.favorited ?? false, post.bookmarked ?? false);
       navigate("post-detail");
     },
-    [navigate]
+    [navigate, initState]
   );
 
   useKeyboard((key) => {
@@ -196,6 +198,11 @@ export function App({ client, user: _user }: AppProps) {
             focused={currentView === "timeline" && !showSplash}
             onPostCountChange={handlePostCountChange}
             onPostSelect={handlePostSelect}
+            onLike={toggleLike}
+            onBookmark={toggleBookmark}
+            getActionState={getState}
+            initActionState={initState}
+            actionMessage={actionMessage}
           />
         </box>
 
@@ -220,6 +227,11 @@ export function App({ client, user: _user }: AppProps) {
             focused={true}
             onBack={handleBackFromProfile}
             onPostSelect={handlePostSelectFromProfile}
+            onLike={toggleLike}
+            onBookmark={toggleBookmark}
+            getActionState={getState}
+            initActionState={initState}
+            actionMessage={actionMessage}
           />
         )}
 
@@ -236,6 +248,11 @@ export function App({ client, user: _user }: AppProps) {
             focused={currentView === "bookmarks" && !showSplash}
             onPostCountChange={handleBookmarkCountChange}
             onPostSelect={handlePostSelect}
+            onLike={toggleLike}
+            onBookmark={toggleBookmark}
+            getActionState={getState}
+            initActionState={initState}
+            actionMessage={actionMessage}
           />
         </box>
       </box>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -11,8 +11,10 @@ export function Footer() {
     >
       <text fg="#ffffff">j/k</text>
       <text fg="#666666"> nav </text>
-      <text fg="#ffffff">1/2</text>
-      <text fg="#666666"> tabs </text>
+      <text fg="#ffffff">l</text>
+      <text fg="#666666"> like </text>
+      <text fg="#ffffff">b</text>
+      <text fg="#666666"> bookmark </text>
       <text fg="#ffffff">r</text>
       <text fg="#666666"> refresh </text>
       <text fg="#ffffff">Tab</text>

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -18,9 +18,19 @@ interface PostCardProps {
   post: TweetData;
   isSelected: boolean;
   id?: string;
+  /** Whether the tweet is liked by the current user */
+  isLiked?: boolean;
+  /** Whether the tweet is bookmarked by the current user */
+  isBookmarked?: boolean;
 }
 
-export function PostCard({ post, isSelected, id }: PostCardProps) {
+export function PostCard({
+  post,
+  isSelected,
+  id,
+  isLiked,
+  isBookmarked,
+}: PostCardProps) {
   const displayText = truncateText(post.text, MAX_TEXT_LINES);
   const timeAgo = formatRelativeTime(post.createdAt);
   const hasMedia = post.media && post.media.length > 0;
@@ -67,6 +77,18 @@ export function PostCard({ post, isSelected, id }: PostCardProps) {
           {formatCount(post.retweetCount)} reposts {"  "}
           {formatCount(post.likeCount)} likes
         </text>
+        {isLiked ? (
+          <text fg="#E0245E">
+            {"  "}
+            {"\u2665"} liked
+          </text>
+        ) : null}
+        {isBookmarked ? (
+          <text fg={X_BLUE}>
+            {"  "}
+            {"\u2691"} saved
+          </text>
+        ) : null}
       </box>
 
       {/* Media indicators - colored labels */}

--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -4,9 +4,11 @@
 
 import type { ScrollBoxRenderable } from "@opentui/core";
 
+import { useKeyboard } from "@opentui/react";
 import { useEffect, useRef } from "react";
 
 import type { TweetData } from "@/api/types";
+import type { TweetActionState } from "@/hooks/useActions";
 
 import { PostCard } from "@/components/PostCard";
 import { useListNavigation } from "@/hooks/useListNavigation";
@@ -16,6 +18,18 @@ interface PostListProps {
   focused?: boolean;
   onPostSelect?: (post: TweetData) => void;
   onSelectedIndexChange?: (index: number) => void;
+  /** Called when user presses 'l' to toggle like on selected post */
+  onLike?: (post: TweetData) => void;
+  /** Called when user presses 'b' to toggle bookmark on selected post */
+  onBookmark?: (post: TweetData) => void;
+  /** Get current action state for a tweet */
+  getActionState?: (tweetId: string) => TweetActionState;
+  /** Initialize action state from API data */
+  initActionState?: (
+    tweetId: string,
+    liked: boolean,
+    bookmarked: boolean
+  ) => void;
 }
 
 /**
@@ -30,6 +44,10 @@ export function PostList({
   focused = false,
   onPostSelect,
   onSelectedIndexChange,
+  onLike,
+  onBookmark,
+  getActionState,
+  initActionState,
 }: PostListProps) {
   const scrollRef = useRef<ScrollBoxRenderable>(null);
   // Save scroll position so we can restore when refocused
@@ -69,6 +87,33 @@ export function PostList({
   useEffect(() => {
     onSelectedIndexChange?.(selectedIndex);
   }, [selectedIndex, onSelectedIndexChange]);
+
+  // Handle like/bookmark keyboard shortcuts
+  useKeyboard((key) => {
+    if (!focused || posts.length === 0) return;
+
+    const currentPost = posts[selectedIndex];
+    if (!currentPost) return;
+
+    if (key.name === "l") {
+      onLike?.(currentPost);
+    } else if (key.name === "b") {
+      onBookmark?.(currentPost);
+    }
+  });
+
+  // Initialize action state for all posts from API data
+  useEffect(() => {
+    if (!initActionState) return;
+
+    for (const post of posts) {
+      initActionState(
+        post.id,
+        post.favorited ?? false,
+        post.bookmarked ?? false
+      );
+    }
+  }, [posts, initActionState]);
 
   // Scroll to keep selected item visible with context (scroll margin)
   // Similar to Vim's scrolloff - keeps items visible above/below selection
@@ -136,14 +181,19 @@ export function PostList({
         height: "100%",
       }}
     >
-      {posts.map((post, index) => (
-        <PostCard
-          key={post.id}
-          id={getPostCardId(post.id)}
-          post={post}
-          isSelected={index === selectedIndex}
-        />
-      ))}
+      {posts.map((post, index) => {
+        const actionState = getActionState?.(post.id);
+        return (
+          <PostCard
+            key={post.id}
+            id={getPostCardId(post.id)}
+            post={post}
+            isSelected={index === selectedIndex}
+            isLiked={actionState?.liked}
+            isBookmarked={actionState?.bookmarked}
+          />
+        );
+      })}
     </scrollbox>
   );
 }

--- a/src/hooks/useActions.ts
+++ b/src/hooks/useActions.ts
@@ -78,9 +78,13 @@ export function useActions({
   const initState = useCallback(
     (tweetId: string, liked: boolean, bookmarked: boolean) => {
       setStates((prev) => {
+        // Only initialize if no state exists yet for this tweet
+        // This preserves user actions (like/bookmark) when navigating back
+        if (prev.has(tweetId)) {
+          return prev;
+        }
         const newMap = new Map(prev);
-        const current = prev.get(tweetId) ?? DEFAULT_STATE;
-        newMap.set(tweetId, { ...current, liked, bookmarked });
+        newMap.set(tweetId, { ...DEFAULT_STATE, liked, bookmarked });
         return newMap;
       });
     },

--- a/src/hooks/useListNavigation.ts
+++ b/src/hooks/useListNavigation.ts
@@ -1,6 +1,6 @@
 /**
  * Vim-style list navigation hook
- * Provides j/k navigation, g/G jump to top/bottom, Enter to select
+ * Provides j/k navigation, g/G jump to top/bottom, Enter/u to select
  */
 
 import { useKeyboard } from "@opentui/react";
@@ -9,7 +9,7 @@ import { useState, useCallback } from "react";
 export interface UseListNavigationOptions {
   /** Total number of items in the list */
   itemCount: number;
-  /** Callback when Enter is pressed on current selection */
+  /** Callback when Enter or u is pressed on current selection */
   onSelect?: (index: number) => void;
   /** Whether this component should handle keyboard input */
   enabled?: boolean;
@@ -95,6 +95,7 @@ export function useListNavigation({
         jumpToBottom();
         break;
       case "return":
+      case "u":
         onSelect?.(selectedIndex);
         break;
     }

--- a/src/screens/BookmarksScreen.tsx
+++ b/src/screens/BookmarksScreen.tsx
@@ -7,6 +7,7 @@ import { useEffect } from "react";
 
 import type { TwitterClient } from "@/api/client";
 import type { TweetData } from "@/api/types";
+import type { TweetActionState } from "@/hooks/useActions";
 
 import { PostList } from "@/components/PostList";
 import { useBookmarks } from "@/hooks/useBookmarks";
@@ -16,6 +17,20 @@ interface BookmarksScreenProps {
   focused?: boolean;
   onPostCountChange?: (count: number) => void;
   onPostSelect?: (post: TweetData) => void;
+  /** Called when user presses 'l' to toggle like */
+  onLike?: (post: TweetData) => void;
+  /** Called when user presses 'b' to toggle bookmark */
+  onBookmark?: (post: TweetData) => void;
+  /** Get current action state for a tweet */
+  getActionState?: (tweetId: string) => TweetActionState;
+  /** Initialize action state from API data */
+  initActionState?: (
+    tweetId: string,
+    liked: boolean,
+    bookmarked: boolean
+  ) => void;
+  /** Action feedback message */
+  actionMessage?: string | null;
 }
 
 function ScreenHeader() {
@@ -41,6 +56,11 @@ export function BookmarksScreen({
   focused = false,
   onPostCountChange,
   onPostSelect,
+  onLike,
+  onBookmark,
+  getActionState,
+  initActionState,
+  actionMessage,
 }: BookmarksScreenProps) {
   const { posts, loading, error, refresh } = useBookmarks({ client });
 
@@ -94,7 +114,22 @@ export function BookmarksScreen({
   return (
     <box style={{ flexDirection: "column", height: "100%" }}>
       <ScreenHeader />
-      <PostList posts={posts} focused={focused} onPostSelect={onPostSelect} />
+      {actionMessage ? (
+        <box style={{ paddingLeft: 1 }}>
+          <text fg={actionMessage.startsWith("Error:") ? "#E0245E" : "#17BF63"}>
+            {actionMessage}
+          </text>
+        </box>
+      ) : null}
+      <PostList
+        posts={posts}
+        focused={focused}
+        onPostSelect={onPostSelect}
+        onLike={onLike}
+        onBookmark={onBookmark}
+        getActionState={getActionState}
+        initActionState={initActionState}
+      />
     </box>
   );
 }

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -8,6 +8,7 @@ import { useState, useCallback } from "react";
 
 import type { TwitterClient } from "@/api/client";
 import type { TweetData } from "@/api/types";
+import type { TweetActionState } from "@/hooks/useActions";
 
 import { PostList } from "@/components/PostList";
 import { useUserProfile } from "@/hooks/useUserProfile";
@@ -21,6 +22,20 @@ interface ProfileScreenProps {
   focused?: boolean;
   onBack?: () => void;
   onPostSelect?: (post: TweetData) => void;
+  /** Called when user presses 'l' to toggle like */
+  onLike?: (post: TweetData) => void;
+  /** Called when user presses 'b' to toggle bookmark */
+  onBookmark?: (post: TweetData) => void;
+  /** Get current action state for a tweet */
+  getActionState?: (tweetId: string) => TweetActionState;
+  /** Initialize action state from API data */
+  initActionState?: (
+    tweetId: string,
+    liked: boolean,
+    bookmarked: boolean
+  ) => void;
+  /** Action feedback message */
+  actionMessage?: string | null;
 }
 
 export function ProfileScreen({
@@ -29,6 +44,11 @@ export function ProfileScreen({
   focused = false,
   onBack,
   onPostSelect,
+  onLike,
+  onBookmark,
+  getActionState,
+  initActionState,
+  actionMessage,
 }: ProfileScreenProps) {
   const { user, tweets, loading, error, refresh } = useUserProfile({
     client,
@@ -128,9 +148,11 @@ export function ProfileScreen({
       <text fg="#ffffff">h/Esc</text>
       <text fg="#666666"> back </text>
       <text fg="#ffffff">j/k</text>
-      <text fg="#666666"> navigate </text>
-      <text fg="#ffffff">Enter</text>
-      <text fg="#666666"> view </text>
+      <text fg="#666666"> nav </text>
+      <text fg="#ffffff">l</text>
+      <text fg="#666666"> like </text>
+      <text fg="#ffffff">b</text>
+      <text fg="#666666"> bookmark </text>
       <text fg="#ffffff">r</text>
       <text fg="#666666"> refresh</text>
     </box>
@@ -176,12 +198,23 @@ export function ProfileScreen({
     <box style={{ flexDirection: "column", height: "100%" }}>
       {isCollapsed ? compactHeader : fullHeader}
       {separator}
+      {actionMessage ? (
+        <box style={{ paddingLeft: 1 }}>
+          <text fg={actionMessage.startsWith("Error:") ? "#E0245E" : "#17BF63"}>
+            {actionMessage}
+          </text>
+        </box>
+      ) : null}
       {tweets.length > 0 ? (
         <PostList
           posts={tweets}
           focused={focused}
           onPostSelect={onPostSelect}
           onSelectedIndexChange={handleSelectedIndexChange}
+          onLike={onLike}
+          onBookmark={onBookmark}
+          getActionState={getActionState}
+          initActionState={initActionState}
         />
       ) : (
         <box style={{ padding: 1, flexGrow: 1 }}>

--- a/src/screens/TimelineScreen.tsx
+++ b/src/screens/TimelineScreen.tsx
@@ -7,6 +7,7 @@ import { useEffect } from "react";
 
 import type { TwitterClient } from "@/api/client";
 import type { TweetData } from "@/api/types";
+import type { TweetActionState } from "@/hooks/useActions";
 
 import { PostList } from "@/components/PostList";
 import { useTimeline, type TimelineTab } from "@/hooks/useTimeline";
@@ -16,6 +17,20 @@ interface TimelineScreenProps {
   focused?: boolean;
   onPostCountChange?: (count: number) => void;
   onPostSelect?: (post: TweetData) => void;
+  /** Called when user presses 'l' to toggle like */
+  onLike?: (post: TweetData) => void;
+  /** Called when user presses 'b' to toggle bookmark */
+  onBookmark?: (post: TweetData) => void;
+  /** Get current action state for a tweet */
+  getActionState?: (tweetId: string) => TweetActionState;
+  /** Initialize action state from API data */
+  initActionState?: (
+    tweetId: string,
+    liked: boolean,
+    bookmarked: boolean
+  ) => void;
+  /** Action feedback message */
+  actionMessage?: string | null;
 }
 
 interface TabBarProps {
@@ -49,6 +64,11 @@ export function TimelineScreen({
   focused = false,
   onPostCountChange,
   onPostSelect,
+  onLike,
+  onBookmark,
+  getActionState,
+  initActionState,
+  actionMessage,
 }: TimelineScreenProps) {
   const { tab, setTab, posts, loading, error, refresh } = useTimeline({
     client,
@@ -112,7 +132,22 @@ export function TimelineScreen({
   return (
     <box style={{ flexDirection: "column", height: "100%" }}>
       <TabBar activeTab={tab} />
-      <PostList posts={posts} focused={focused} onPostSelect={onPostSelect} />
+      {actionMessage ? (
+        <box style={{ paddingLeft: 1 }}>
+          <text fg={actionMessage.startsWith("Error:") ? "#E0245E" : "#17BF63"}>
+            {actionMessage}
+          </text>
+        </box>
+      ) : null}
+      <PostList
+        posts={posts}
+        focused={focused}
+        onPostSelect={onPostSelect}
+        onLike={onLike}
+        onBookmark={onBookmark}
+        getActionState={getActionState}
+        initActionState={initActionState}
+      />
     </box>
   );
 }


### PR DESCRIPTION
## Summary

- Extract `favorited` and `bookmarked` fields from Twitter API responses in TweetData
- Add keyboard shortcuts (l=like, b=bookmark) to list views (Timeline, Bookmarks, Profile)
- Display visual indicators in PostCard showing liked/bookmarked status
- Initialize action state from API data when posts load and preserve state when navigating

## Test Plan

- All 215 tests pass
- Keyboard shortcuts work in Timeline, Bookmarks, and Profile screens
- Visual indicators display correctly when posts are liked/bookmarked
- State persists when navigating away and back to posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)