### PR TITLE
feat: Implement infinite scroll pagination for Timeline and Bookmarks

### DIFF
--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -30,6 +30,12 @@ interface PostListProps {
     liked: boolean,
     bookmarked: boolean
   ) => void;
+  /** Called when user scrolls near the bottom to load more posts */
+  onLoadMore?: () => void;
+  /** Whether more posts are currently being loaded */
+  loadingMore?: boolean;
+  /** Whether there are more posts available to load */
+  hasMore?: boolean;
 }
 
 /**
@@ -48,6 +54,9 @@ export function PostList({
   onBookmark,
   getActionState,
   initActionState,
+  onLoadMore,
+  loadingMore = false,
+  hasMore = true,
 }: PostListProps) {
   const scrollRef = useRef<ScrollBoxRenderable>(null);
   // Save scroll position so we can restore when refocused
@@ -164,6 +173,17 @@ export function PostList({
     }
   }, [selectedIndex, posts.length]);
 
+  // Trigger load more when approaching the end of the list
+  useEffect(() => {
+    if (!onLoadMore || loadingMore || !hasMore || posts.length === 0) return;
+
+    // Load more when within 5 items of the end
+    const threshold = 5;
+    if (selectedIndex >= posts.length - threshold) {
+      onLoadMore();
+    }
+  }, [selectedIndex, posts.length, onLoadMore, loadingMore, hasMore]);
+
   if (posts.length === 0) {
     return (
       <box style={{ padding: 2 }}>
@@ -194,6 +214,16 @@ export function PostList({
           />
         );
       })}
+      {loadingMore ? (
+        <box style={{ padding: 1, paddingLeft: 2 }}>
+          <text fg="#888888">Loading more posts...</text>
+        </box>
+      ) : null}
+      {!hasMore && posts.length > 0 ? (
+        <box style={{ padding: 1, paddingLeft: 2 }}>
+          <text fg="#666666">No more posts</text>
+        </box>
+      ) : null}
     </scrollbox>
   );
 }

--- a/src/screens/BookmarksScreen.tsx
+++ b/src/screens/BookmarksScreen.tsx
@@ -80,9 +80,12 @@ export function BookmarksScreen({
   const {
     posts,
     loading,
+    loadingMore,
+    hasMore,
     error,
     apiError,
     refresh,
+    loadMore,
     retryBlocked,
     retryCountdown,
   } = useBookmarks({ client });
@@ -173,6 +176,9 @@ export function BookmarksScreen({
         onBookmark={onBookmark}
         getActionState={getActionState}
         initActionState={initActionState}
+        onLoadMore={loadMore}
+        loadingMore={loadingMore}
+        hasMore={hasMore}
       />
     </box>
   );

--- a/src/screens/TimelineScreen.tsx
+++ b/src/screens/TimelineScreen.tsx
@@ -90,9 +90,12 @@ export function TimelineScreen({
     setTab,
     posts,
     loading,
+    loadingMore,
+    hasMore,
     error,
     apiError,
     refresh,
+    loadMore,
     retryBlocked,
     retryCountdown,
   } = useTimeline({
@@ -195,6 +198,9 @@ export function TimelineScreen({
         onBookmark={onBookmark}
         getActionState={getActionState}
         initActionState={initActionState}
+        onLoadMore={loadMore}
+        loadingMore={loadingMore}
+        hasMore={hasMore}
       />
     </box>
   );


### PR DESCRIPTION
## Summary

Implements infinite scroll pagination for Timeline and Bookmarks views. Users can now scroll near the bottom to automatically load more posts, with proper deduplication and loading indicators.

## Key Changes

**API Layer:** Updated `getBookmarks()` to accept optional cursor parameter and return `TimelineResult` with nextCursor support. Fixed URL extraction bug where undefined `expandedUrl` caused crashes.

**Hook Layer:** Added pagination state (loadingMore, hasMore, nextCursor) to both `useTimeline` and `useBookmarks`. Implemented deduplication via seenIds ref to filter duplicate posts across pages.

**UI Layer:** Added scroll detection to PostList that triggers loadMore when within 5 items of end. Shows loading indicator and "No more posts" message. Updated both screen components to pass pagination props.

**Tests:** Added 6 new unit tests covering getBookmarks pagination and URL extraction edge cases.

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)