### PR TITLE
feat(notifications): Implement pagination with infinite scroll

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -2781,11 +2781,18 @@ export class TwitterClient {
   /**
    * Get the authenticated user's notifications
    */
-  async getNotifications(count = 20): Promise<NotificationsResult> {
-    const variables = {
+  async getNotifications(
+    count = 20,
+    cursor?: string
+  ): Promise<NotificationsResult> {
+    const variables: Record<string, unknown> = {
       timeline_type: "All",
       count,
     };
+
+    if (cursor) {
+      variables.cursor = cursor;
+    }
 
     const features = this.buildTimelineFeatures();
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,6 +6,16 @@ interface HeaderProps {
   unreadNotificationCount?: number;
 }
 
+function getCountLabel(view: View, count: number): string {
+  if (view === "notifications") {
+    return `${count} notifications`;
+  }
+  if (view === "bookmarks") {
+    return `${count} bookmarked`;
+  }
+  return `${count} posts`;
+}
+
 export function Header({
   currentView,
   postCount,
@@ -30,7 +40,7 @@ export function Header({
       <text fg="#666666"> | </text>
       <text fg="#ffffff">{viewLabel}</text>
       {postCount !== undefined && postCount > 0 && (
-        <text fg="#666666"> ({postCount} posts)</text>
+        <text fg="#666666"> ({getCountLabel(currentView, postCount)})</text>
       )}
     </box>
   );

--- a/src/components/NotificationList.tsx
+++ b/src/components/NotificationList.tsx
@@ -15,6 +15,9 @@ interface NotificationListProps {
   notifications: NotificationData[];
   focused?: boolean;
   onNotificationSelect?: (notification: NotificationData) => void;
+  onLoadMore?: () => void;
+  loadingMore?: boolean;
+  hasMore?: boolean;
 }
 
 /**
@@ -28,6 +31,9 @@ export function NotificationList({
   notifications,
   focused = false,
   onNotificationSelect,
+  onLoadMore,
+  loadingMore = false,
+  hasMore = true,
 }: NotificationListProps) {
   const scrollRef = useRef<ScrollBoxRenderable>(null);
   const savedScrollTop = useRef(0);
@@ -98,6 +104,18 @@ export function NotificationList({
     }
   }, [selectedIndex, notifications.length]);
 
+  // Trigger load more when approaching the end of the list
+  useEffect(() => {
+    if (!onLoadMore || loadingMore || !hasMore || notifications.length === 0)
+      return;
+
+    // Load more when within 5 items of the end
+    const threshold = 5;
+    if (selectedIndex >= notifications.length - threshold) {
+      onLoadMore();
+    }
+  }, [selectedIndex, notifications.length, onLoadMore, loadingMore, hasMore]);
+
   if (notifications.length === 0) {
     return (
       <box style={{ padding: 2 }}>
@@ -123,6 +141,16 @@ export function NotificationList({
           isSelected={index === selectedIndex}
         />
       ))}
+      {loadingMore ? (
+        <box style={{ padding: 1, paddingLeft: 2 }}>
+          <text fg="#888888">Loading more...</text>
+        </box>
+      ) : null}
+      {!hasMore && notifications.length > 0 ? (
+        <box style={{ padding: 1, paddingLeft: 2 }}>
+          <text fg="#666666">No more notifications</text>
+        </box>
+      ) : null}
     </scrollbox>
   );
 }

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -19,12 +19,18 @@ export interface UseNotificationsResult {
   unreadCount: number;
   /** Whether data is currently loading */
   loading: boolean;
+  /** Whether more notifications are being loaded (pagination) */
+  loadingMore: boolean;
+  /** Whether there are more notifications to load */
+  hasMore: boolean;
   /** Error message if fetch failed */
   error: string | null;
   /** Typed error with rate limit info, auth status, etc. */
   apiError: ApiError | null;
   /** Refresh notifications */
   refresh: () => void;
+  /** Load more notifications (pagination) */
+  loadMore: () => void;
   /** Whether retry is currently blocked (e.g., rate limit countdown) */
   retryBlocked: boolean;
   /** Seconds until retry is allowed (for rate limit countdown) */
@@ -37,11 +43,15 @@ export function useNotifications({
   const [notifications, setNotifications] = useState<NotificationData[]>([]);
   const [unreadCount, setUnreadCount] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [nextCursor, setNextCursor] = useState<string | undefined>();
+  const [hasMore, setHasMore] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [apiError, setApiError] = useState<ApiError | null>(null);
   const [refreshCounter, setRefreshCounter] = useState(0);
   const [retryCountdown, setRetryCountdown] = useState(0);
   const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const seenIds = useRef(new Set<string>());
 
   // Clear countdown timer on unmount
   useEffect(() => {
@@ -56,11 +66,19 @@ export function useNotifications({
     setLoading(true);
     setError(null);
     setApiError(null);
+    seenIds.current.clear();
 
     const result = await client.getNotifications(30);
 
     if (result.success) {
+      // Track seen IDs for deduplication during pagination
+      for (const notif of result.notifications) {
+        seenIds.current.add(notif.id);
+      }
+
       setNotifications(result.notifications);
+      setNextCursor(result.bottomCursor);
+      setHasMore(!!result.bottomCursor && result.notifications.length > 0);
 
       // Calculate unread count based on sort_index comparison
       if (result.unreadSortIndex) {
@@ -120,13 +138,43 @@ export function useNotifications({
     setRefreshCounter((prev) => prev + 1);
   }, [retryCountdown]);
 
+  const loadMore = useCallback(async () => {
+    if (!nextCursor || loadingMore || !hasMore) return;
+
+    setLoadingMore(true);
+
+    const result = await client.getNotifications(30, nextCursor);
+
+    if (result.success) {
+      // Filter out duplicates using seenIds
+      const newNotifications = result.notifications.filter(
+        (n) => !seenIds.current.has(n.id)
+      );
+      for (const notif of newNotifications) {
+        seenIds.current.add(notif.id);
+      }
+
+      setNotifications((prev) => [...prev, ...newNotifications]);
+      setNextCursor(result.bottomCursor);
+      setHasMore(!!result.bottomCursor && result.notifications.length > 0);
+    } else {
+      // Stop pagination on error
+      setHasMore(false);
+    }
+
+    setLoadingMore(false);
+  }, [client, nextCursor, loadingMore, hasMore]);
+
   return {
     notifications,
     unreadCount,
     loading,
+    loadingMore,
+    hasMore,
     error,
     apiError,
     refresh,
+    loadMore,
     retryBlocked: retryCountdown > 0,
     retryCountdown,
   };

--- a/src/screens/NotificationsScreen.tsx
+++ b/src/screens/NotificationsScreen.tsx
@@ -67,9 +67,12 @@ export function NotificationsScreen({
     notifications,
     unreadCount,
     loading,
+    loadingMore,
+    hasMore,
     error,
     apiError,
     refresh,
+    loadMore,
     retryBlocked,
     retryCountdown,
   } = useNotifications({ client });
@@ -160,6 +163,9 @@ export function NotificationsScreen({
         notifications={notifications}
         focused={focused}
         onNotificationSelect={onNotificationSelect}
+        onLoadMore={loadMore}
+        loadingMore={loadingMore}
+        hasMore={hasMore}
       />
     </box>
   );

--- a/src/screens/TimelineScreen.tsx
+++ b/src/screens/TimelineScreen.tsx
@@ -129,7 +129,7 @@ export function TimelineScreen({
   if (loading) {
     return (
       <box style={{ flexDirection: "column", height: "100%" }}>
-        <TabBar activeTab={tab} />
+        {focused && <TabBar activeTab={tab} />}
         <box style={{ padding: 2, flexGrow: 1 }}>
           <text fg="#888888">Loading timeline...</text>
         </box>
@@ -140,7 +140,7 @@ export function TimelineScreen({
   if (apiError) {
     return (
       <box style={{ flexDirection: "column", height: "100%" }}>
-        <TabBar activeTab={tab} />
+        {focused && <TabBar activeTab={tab} />}
         <ErrorBanner
           error={apiError}
           onRetry={refresh}
@@ -160,7 +160,7 @@ export function TimelineScreen({
   if (error) {
     return (
       <box style={{ flexDirection: "column", height: "100%" }}>
-        <TabBar activeTab={tab} />
+        {focused && <TabBar activeTab={tab} />}
         <box style={{ padding: 2, flexGrow: 1 }}>
           <text fg="#ff6666">Error: {error}</text>
           <text fg="#888888"> Press r to retry.</text>
@@ -172,7 +172,7 @@ export function TimelineScreen({
   if (posts.length === 0) {
     return (
       <box style={{ flexDirection: "column", height: "100%" }}>
-        <TabBar activeTab={tab} />
+        {focused && <TabBar activeTab={tab} />}
         <box style={{ padding: 2, flexGrow: 1 }}>
           <text fg="#888888">No posts to display. Press r to refresh.</text>
         </box>
@@ -182,7 +182,7 @@ export function TimelineScreen({
 
   return (
     <box style={{ flexDirection: "column", height: "100%" }}>
-      <TabBar activeTab={tab} />
+      {focused && <TabBar activeTab={tab} />}
       {actionMessage ? (
         <box style={{ paddingLeft: 1 }}>
           <text fg={actionMessage.startsWith("Error:") ? "#E0245E" : "#17BF63"}>


### PR DESCRIPTION
## Summary

Implements cursor-based pagination for notifications with infinite scroll, following the same pattern used in Timeline and Bookmarks. Notifications now load 30 items at a time and automatically fetch more when navigating near the end of the list.

## Changes

- **API**: Added optional cursor parameter to `getNotifications()` for pagination support
- **Hook**: Added `loadMore` callback with deduplication using `seenIds` Set
- **Component**: Added pagination props and trigger effect when within 5 items of end
- **UI**: Shows "Loading more..." and "No more notifications" states
- **Bugfixes**: Fixed header to show view-specific count labels and prevented Timeline TabBar from bleeding through

Fixes #70