### PR TITLE
feat(FolderPicker): Add scrolling and pagination for large folder lists

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -3558,7 +3558,7 @@ export class TwitterClient {
    * Get the authenticated user's bookmark folders
    */
   async getBookmarkFolders(): Promise<import("./types").BookmarkFoldersResult> {
-    const variables = {};
+    const variables = { count: 100 };
     const features = this.buildBookmarksFeatures();
 
     const params = new URLSearchParams({


### PR DESCRIPTION
## Summary

- Increased API folder request count to support up to 100 folders
- Replaced scrollbox with windowed list pattern for reliable modal layout
- Added visual indicators (↑ more / ↓ more) for hidden folders
- Documented windowed list pattern in OpenTUI skill for future reference

All tests pass. j/k navigation works smoothly through all folders with automatic viewport adjustment.

Fixes #68