### PR TITLE
feat(tui): Show replies and thread context in post detail view

### DIFF
--- a/src/hooks/usePostDetail.ts
+++ b/src/hooks/usePostDetail.ts
@@ -1,26 +1,106 @@
 /**
- * usePostDetail - Hook for managing single post detail view state
- * Accepts initial tweet data from timeline for immediate display
+ * usePostDetail - Hook for fetching thread context (parent tweet and replies)
+ * Shows initial tweet immediately, then fetches additional context in background
  */
 
+import { useState, useEffect, useCallback } from "react";
+
+import type { TwitterClient } from "@/api/client";
 import type { TweetData } from "@/api/types";
 
 export interface UsePostDetailOptions {
+  /** Twitter API client */
+  client: TwitterClient;
   /** Initial tweet data (passed from timeline for immediate display) */
   tweet: TweetData;
 }
 
 export interface UsePostDetailResult {
-  /** The tweet data */
+  /** The main tweet data */
   tweet: TweetData;
+  /** Parent tweet if this is a reply (null if not a reply or still loading) */
+  parentTweet: TweetData | null;
+  /** Replies to this tweet */
+  replies: TweetData[];
+  /** Whether parent tweet is loading */
+  loadingParent: boolean;
+  /** Whether replies are loading */
+  loadingReplies: boolean;
+  /** Error fetching parent (if any) */
+  parentError: string | null;
+  /** Error fetching replies (if any) */
+  repliesError: string | null;
+  /** Refresh replies */
+  refreshReplies: () => void;
 }
 
 export function usePostDetail({
+  client,
   tweet,
 }: UsePostDetailOptions): UsePostDetailResult {
-  // For now, just return the passed tweet data
-  // Future: could add refresh capability, thread fetching, etc.
+  const [parentTweet, setParentTweet] = useState<TweetData | null>(null);
+  const [replies, setReplies] = useState<TweetData[]>([]);
+  const [loadingParent, setLoadingParent] = useState(false);
+  const [loadingReplies, setLoadingReplies] = useState(false);
+  const [parentError, setParentError] = useState<string | null>(null);
+  const [repliesError, setRepliesError] = useState<string | null>(null);
+
+  // Fetch parent tweet if this is a reply
+  useEffect(() => {
+    const parentId = tweet.inReplyToStatusId;
+    if (!parentId) {
+      setParentTweet(null);
+      setLoadingParent(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoadingParent(true);
+    setParentError(null);
+
+    client.getTweet(parentId).then((result) => {
+      if (cancelled) return;
+      setLoadingParent(false);
+      if (result.success && result.tweet) {
+        setParentTweet(result.tweet);
+      } else {
+        setParentError(result.error ?? "Failed to fetch parent tweet");
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [client, tweet.inReplyToStatusId]);
+
+  // Fetch replies
+  const fetchReplies = useCallback(async () => {
+    setLoadingReplies(true);
+    setRepliesError(null);
+
+    const result = await client.getReplies(tweet.id);
+
+    setLoadingReplies(false);
+    if (result.success && result.tweets) {
+      setReplies(result.tweets);
+    } else {
+      setRepliesError(result.error ?? "Failed to fetch replies");
+    }
+  }, [client, tweet.id]);
+
+  // Fetch replies on mount
+  useEffect(() => {
+    fetchReplies();
+  }, [fetchReplies]);
+
   return {
     tweet,
+    parentTweet,
+    replies,
+    loadingParent,
+    loadingReplies,
+    parentError,
+    repliesError,
+    refreshReplies: fetchReplies,
   };
 }


### PR DESCRIPTION
## Summary
- Display parent tweet context when viewing a reply (shows "Replying to @user")
- Show replies list below main tweet with `r` to toggle navigation mode
- Support keyboard navigation through replies (j/k) and opening reply details (Enter)
- Proper back navigation when drilling into replies using a post stack

Fixes #34

## Test plan
- [ ] Open a tweet that is a reply → verify parent tweet context shows
- [ ] Open a tweet with replies → verify replies list appears below
- [ ] Press `r` to enter replies mode, navigate with j/k, press Enter to open reply
- [ ] Press Esc to go back through the post stack correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)