### PR TITLE
feat(auth): Browser selection, token persistence, session expiration

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@opentui/core": "^0.1.68",
         "@opentui/react": "^0.1.68",
-        "@steipete/sweet-cookie": "0.1.0",
+        "@steipete/sweet-cookie": "^0.1.0",
         "cac": "^6.7.14",
         "react": "^19.2.0",
         "x-client-transaction-id": "^0.1.9",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@opentui/core": "^0.1.68",
     "@opentui/react": "^0.1.68",
-    "@steipete/sweet-cookie": "0.1.0",
+    "@steipete/sweet-cookie": "^0.1.0",
     "cac": "^6.7.14",
     "react": "^19.2.0",
     "x-client-transaction-id": "^0.1.9"

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -208,6 +208,8 @@ export interface TwitterClientOptions {
   timeoutMs?: number;
   /** Max depth for quoted tweets (0 disables, default: 1) */
   quoteDepth?: number;
+  /** Callback when session expires (401/403 errors) */
+  onSessionExpired?: () => void;
 }
 
 /**

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -8,6 +8,7 @@ import { ExitConfirmationModal } from "@/components/ExitConfirmationModal";
 import { FolderPicker } from "@/components/FolderPicker";
 import { Footer } from "@/components/Footer";
 import { Header } from "@/components/Header";
+import { SessionExpiredModal } from "@/components/SessionExpiredModal";
 import { useActions } from "@/hooks/useActions";
 import { useNavigation } from "@/hooks/useNavigation";
 import { BookmarksScreen } from "@/screens/BookmarksScreen";
@@ -49,6 +50,14 @@ export function App({ client, user: _user }: AppProps) {
   const [unreadNotificationCount, setUnreadNotificationCount] = useState(0);
   const [actionMessage, setActionMessage] = useState<string | null>(null);
   const [showFooter, setShowFooter] = useState(true);
+  const [sessionExpired, setSessionExpired] = useState(false);
+
+  // Set up session expired callback
+  useEffect(() => {
+    client.setOnSessionExpired(() => {
+      setSessionExpired(true);
+    });
+  }, [client]);
 
   // Actions hook for like/bookmark mutations
   const { toggleLike, toggleBookmark, getState, initState } = useActions({
@@ -535,6 +544,9 @@ export function App({ client, user: _user }: AppProps) {
           />
         </box>
       )}
+
+      {/* Session expired modal overlay */}
+      {sessionExpired && <SessionExpiredModal />}
     </box>
   );
 }

--- a/src/auth/browser-detect.ts
+++ b/src/auth/browser-detect.ts
@@ -1,0 +1,133 @@
+import { existsSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+import type { BrowserId } from "@/config/types";
+
+export interface AvailableBrowser {
+  id: BrowserId;
+  name: string;
+}
+
+interface BrowserConfig {
+  id: BrowserId;
+  name: string;
+  /** Function to check if the browser has cookies available */
+  check: () => boolean;
+}
+
+const home = homedir();
+
+const BROWSER_CONFIGS: BrowserConfig[] = [
+  {
+    id: "safari",
+    name: "Safari",
+    check: () =>
+      // Modern Safari (sandboxed container)
+      existsSync(
+        path.join(
+          home,
+          "Library/Containers/com.apple.Safari/Data/Library/Cookies/Cookies.binarycookies"
+        )
+      ) ||
+      // Legacy Safari (pre-sandbox)
+      existsSync(path.join(home, "Library/Cookies/Cookies.binarycookies")),
+  },
+  {
+    id: "chrome",
+    name: "Chrome",
+    check: () =>
+      existsSync(
+        path.join(
+          home,
+          "Library/Application Support/Google/Chrome/Default/Cookies"
+        )
+      ) ||
+      existsSync(
+        path.join(
+          home,
+          "Library/Application Support/Google/Chrome/Default/Network/Cookies"
+        )
+      ),
+  },
+  {
+    id: "brave",
+    name: "Brave",
+    check: () =>
+      existsSync(
+        path.join(
+          home,
+          "Library/Application Support/BraveSoftware/Brave-Browser/Default/Cookies"
+        )
+      ) ||
+      existsSync(
+        path.join(
+          home,
+          "Library/Application Support/BraveSoftware/Brave-Browser/Default/Network/Cookies"
+        )
+      ),
+  },
+  {
+    id: "arc",
+    name: "Arc",
+    check: () =>
+      existsSync(
+        path.join(
+          home,
+          "Library/Application Support/Arc/User Data/Default/Cookies"
+        )
+      ) ||
+      existsSync(
+        path.join(
+          home,
+          "Library/Application Support/Arc/User Data/Default/Network/Cookies"
+        )
+      ),
+  },
+  {
+    id: "firefox",
+    name: "Firefox",
+    check: () => {
+      const profilesDir = path.join(
+        home,
+        "Library/Application Support/Firefox/Profiles"
+      );
+      if (!existsSync(profilesDir)) return false;
+      try {
+        const profiles = readdirSync(profilesDir);
+        return profiles.some((profile) =>
+          existsSync(path.join(profilesDir, profile, "cookies.sqlite"))
+        );
+      } catch {
+        return false;
+      }
+    },
+  },
+];
+
+/**
+ * Detect which browsers have cookie databases available.
+ * Returns only browsers that have cookies we can potentially read.
+ */
+export function detectAvailableBrowsers(): AvailableBrowser[] {
+  return BROWSER_CONFIGS.filter((config) => config.check()).map((config) => ({
+    id: config.id,
+    name: config.name,
+  }));
+}
+
+/**
+ * Get display name for a browser ID.
+ */
+export function getBrowserName(id: BrowserId): string {
+  const config = BROWSER_CONFIGS.find((c) => c.id === id);
+  return config?.name ?? id;
+}
+
+/**
+ * Check if stdin is interactive (TTY).
+ * Used to determine if we can prompt the user.
+ */
+export function isInteractive(): boolean {
+  return process.stdin.isTTY === true;
+}

--- a/src/auth/browser-picker.ts
+++ b/src/auth/browser-picker.ts
@@ -1,0 +1,118 @@
+import { createInterface } from "node:readline";
+
+import type { BrowserId } from "@/config/types";
+
+import type { AvailableBrowser } from "./browser-detect";
+
+export interface BrowserPickerResult {
+  ok: true;
+  browser: BrowserId;
+}
+
+export interface BrowserPickerManual {
+  ok: true;
+  manual: true;
+}
+
+export interface BrowserPickerCancelled {
+  ok: false;
+  reason: "cancelled" | "no-browsers";
+}
+
+/** Check if any detected browsers are Chromium-based (will trigger keychain prompt) */
+function hasChromiumBrowser(browsers: AvailableBrowser[]): boolean {
+  return browsers.some((b) => ["chrome", "brave", "arc"].includes(b.id));
+}
+
+/**
+ * Prompt user to select a browser from available options.
+ * Runs in CLI before TUI launches.
+ *
+ * Returns the selected browser ID, manual entry flag, or cancellation.
+ */
+export async function promptBrowserSelection(
+  browsers: AvailableBrowser[]
+): Promise<BrowserPickerResult | BrowserPickerManual | BrowserPickerCancelled> {
+  if (browsers.length === 0) {
+    return { ok: false, reason: "no-browsers" };
+  }
+
+  // Auto-select if only one browser available (but still show keychain info)
+  if (browsers.length === 1 && browsers[0]) {
+    if (hasChromiumBrowser(browsers)) {
+      console.log(
+        "\nNote: macOS will ask for keychain access. Click 'Always Allow' to avoid future prompts.\n"
+      );
+    }
+    console.log(`Using ${browsers[0].name} for Twitter cookies.\n`);
+    return { ok: true, browser: browsers[0].id };
+  }
+
+  return new Promise((resolve) => {
+    const rl = createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+
+    // Handle Ctrl+C
+    rl.on("close", () => {
+      resolve({ ok: false, reason: "cancelled" });
+    });
+
+    // Show keychain info for Chromium browsers
+    if (hasChromiumBrowser(browsers)) {
+      console.log(
+        "\nNote: Chromium browsers (Chrome/Brave/Arc) require keychain access."
+      );
+      console.log(
+        "      macOS will prompt for your password. Click 'Always Allow' to save.\n"
+      );
+    }
+
+    console.log("Select browser to read Twitter cookies from:\n");
+
+    for (let i = 0; i < browsers.length; i++) {
+      const browser = browsers[i];
+      if (browser) {
+        console.log(`  [${i + 1}] ${browser.name}`);
+      }
+    }
+
+    console.log(`  [M] Enter tokens manually (default)\n`);
+
+    const askQuestion = (): void => {
+      rl.question(`Choice (1-${browsers.length} or M) [M]: `, (answer) => {
+        const trimmed = answer.trim().toLowerCase();
+
+        // Empty input or 'm' - manual entry
+        if (trimmed === "" || trimmed === "m") {
+          resolve({ ok: true, manual: true });
+          rl.close();
+          return;
+        }
+
+        const choice = Number.parseInt(trimmed, 10);
+
+        if (Number.isNaN(choice) || choice < 1 || choice > browsers.length) {
+          console.log(
+            `Please enter a number between 1 and ${browsers.length}, or M for manual`
+          );
+          askQuestion();
+          return;
+        }
+
+        const selected = browsers[choice - 1];
+        if (selected) {
+          // Resolve BEFORE closing - close() synchronously triggers the 'close' event
+          console.log(`\nUsing ${selected.name}.\n`);
+          resolve({ ok: true, browser: selected.id });
+          rl.close();
+        } else {
+          askQuestion();
+        }
+      });
+    };
+
+    askQuestion();
+  });
+}

--- a/src/auth/cookies.test.ts
+++ b/src/auth/cookies.test.ts
@@ -143,7 +143,7 @@ describe("cookies", () => {
       const result = await resolveCredentials({});
 
       expect(result.cookies.authToken).toBe("chrome-auth");
-      expect(result.cookies.source).toBe("Chrome default profile");
+      expect(result.cookies.source).toBe("Chrome");
     });
 
     it("uses specific cookie source when provided", async () => {
@@ -155,7 +155,7 @@ describe("cookies", () => {
       const result = await resolveCredentials({ cookieSource: "firefox" });
 
       expect(result.cookies.authToken).toBe("firefox-auth");
-      expect(result.cookies.source).toBe("Firefox default profile");
+      expect(result.cookies.source).toBe("Firefox");
     });
 
     it("uses array of cookie sources", async () => {
@@ -399,7 +399,7 @@ describe("cookies", () => {
       const result = await extractCookiesFromChrome();
 
       expect(result.cookies.authToken).toBe("chrome-auth");
-      expect(result.cookies.source).toBe("Chrome default profile");
+      expect(result.cookies.source).toBe("Chrome");
     });
 
     it("extracts cookies from Chrome specific profile", async () => {
@@ -430,7 +430,7 @@ describe("cookies", () => {
       const result = await extractCookiesFromFirefox();
 
       expect(result.cookies.authToken).toBe("firefox-auth");
-      expect(result.cookies.source).toBe("Firefox default profile");
+      expect(result.cookies.source).toBe("Firefox");
     });
 
     it("extracts cookies from Firefox specific profile", async () => {

--- a/src/auth/manual-entry.ts
+++ b/src/auth/manual-entry.ts
@@ -1,0 +1,88 @@
+import { createInterface } from "node:readline";
+
+import { checkAuth } from "./check";
+
+export interface ManualTokens {
+  authToken: string;
+  ct0: string;
+}
+
+export interface ManualEntryResult {
+  ok: true;
+  tokens: ManualTokens;
+}
+
+export interface ManualEntryCancelled {
+  ok: false;
+  reason: "cancelled";
+}
+
+/**
+ * Prompt user to manually enter auth tokens.
+ * Validates tokens before accepting them.
+ */
+export async function promptManualTokenEntry(): Promise<
+  ManualEntryResult | ManualEntryCancelled
+> {
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  let cancelled = false;
+
+  // Handle Ctrl+C
+  rl.on("close", () => {
+    cancelled = true;
+  });
+
+  const question = (prompt: string): Promise<string> =>
+    new Promise((resolve) => {
+      rl.question(prompt, (answer) => {
+        resolve(answer.trim());
+      });
+    });
+
+  console.log("\n┌─────────────────────────────────────────────────────────┐");
+  console.log("│  Manual Token Entry                                     │");
+  console.log("└─────────────────────────────────────────────────────────┘\n");
+  console.log("To get your tokens:");
+  console.log("  1. Open x.com in your browser and log in");
+  console.log("  2. Open DevTools (Cmd+Option+I or F12)");
+  console.log("  3. Go to Application tab → Cookies → https://x.com");
+  console.log("  4. Find 'auth_token' and 'ct0' rows, copy their values\n");
+
+  // Loop until valid tokens or cancelled
+  while (!cancelled) {
+    const authToken = await question("auth_token: ");
+    if (authToken === "" || cancelled) {
+      console.log("\nCancelled.");
+      rl.close();
+      return { ok: false, reason: "cancelled" };
+    }
+
+    const ct0 = await question("ct0: ");
+    if (ct0 === "" || cancelled) {
+      console.log("\nCancelled.");
+      rl.close();
+      return { ok: false, reason: "cancelled" };
+    }
+
+    // Validate tokens
+    console.log("\nValidating...");
+    const result = await checkAuth({ authToken, ct0 });
+
+    if (result.ok) {
+      console.log("Tokens valid.\n");
+      rl.close();
+      return { ok: true, tokens: { authToken, ct0 } };
+    }
+
+    // Show error and retry
+    console.log(`\nInvalid tokens: ${result.error}\n`);
+    console.log("Try again or press Enter to cancel.\n");
+  }
+
+  rl.close();
+  return { ok: false, reason: "cancelled" };
+}

--- a/src/auth/session.ts
+++ b/src/auth/session.ts
@@ -1,0 +1,30 @@
+/**
+ * Session state management for handling expired auth.
+ */
+
+export type SessionStatus = "valid" | "expired" | "refreshing";
+
+export interface SessionState {
+  status: SessionStatus;
+}
+
+/**
+ * Create initial valid session state.
+ */
+export function createValidSession(): SessionState {
+  return { status: "valid" };
+}
+
+/**
+ * Create expired session state.
+ */
+export function createExpiredSession(): SessionState {
+  return { status: "expired" };
+}
+
+/**
+ * Create refreshing session state.
+ */
+export function createRefreshingSession(): SessionState {
+  return { status: "refreshing" };
+}

--- a/src/components/SessionExpiredModal.tsx
+++ b/src/components/SessionExpiredModal.tsx
@@ -1,0 +1,45 @@
+import { useKeyboard, useRenderer } from "@opentui/react";
+
+export function SessionExpiredModal() {
+  const renderer = useRenderer();
+
+  useKeyboard((key) => {
+    if (key.name === "return" || key.name === "q" || key.name === "escape") {
+      renderer.destroy();
+    }
+  });
+
+  return (
+    <box
+      style={{
+        position: "absolute",
+        top: 0,
+        left: 0,
+        width: "100%",
+        height: "100%",
+        justifyContent: "center",
+        alignItems: "center",
+      }}
+    >
+      <box
+        style={{
+          borderStyle: "single",
+          padding: 2,
+          flexDirection: "column",
+          alignItems: "center",
+          gap: 1,
+        }}
+        backgroundColor="#1a1a2e"
+        borderColor="#e63946"
+      >
+        <text fg="#e63946">Session Expired</text>
+        <text fg="#a8a8a8">Your tokens are no longer valid.</text>
+        <box style={{ marginTop: 1, flexDirection: "row" }}>
+          <text fg="#6b6b6b">Press </text>
+          <text fg="#ffffff">Enter</text>
+          <text fg="#6b6b6b"> to quit</text>
+        </box>
+      </box>
+    </box>
+  );
+}

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,2 +1,69 @@
-// TOML config loading
-// TODO: Implement in #12
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+import type { XfeedConfig } from "./types";
+
+const CONFIG_DIR = path.join(homedir(), ".config", "xfeed");
+const CONFIG_PATH = path.join(CONFIG_DIR, "config.json");
+
+/**
+ * Load config from ~/.config/xfeed/config.json
+ * Returns empty config if file doesn't exist or is invalid JSON.
+ */
+export function loadConfig(): XfeedConfig {
+  if (!existsSync(CONFIG_PATH)) {
+    return {};
+  }
+
+  try {
+    const content = readFileSync(CONFIG_PATH, "utf-8");
+    const parsed: unknown = JSON.parse(content);
+    if (typeof parsed !== "object" || parsed === null) {
+      return {};
+    }
+    return parsed as XfeedConfig;
+  } catch {
+    // Corrupt JSON - return empty config
+    return {};
+  }
+}
+
+/**
+ * Save config to ~/.config/xfeed/config.json
+ * Creates directory if it doesn't exist.
+ */
+export function saveConfig(config: XfeedConfig): void {
+  if (!existsSync(CONFIG_DIR)) {
+    mkdirSync(CONFIG_DIR, { recursive: true });
+  }
+  writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2) + "\n");
+}
+
+/**
+ * Update specific fields in config while preserving others.
+ */
+export function updateConfig(updates: Partial<XfeedConfig>): void {
+  const existing = loadConfig();
+  saveConfig({ ...existing, ...updates });
+}
+
+/**
+ * Clear all saved auth data (browser preference and tokens).
+ */
+export function clearBrowserPreference(): void {
+  const config = loadConfig();
+  delete config.browser;
+  delete config.chromeProfile;
+  delete config.firefoxProfile;
+  delete config.authToken;
+  delete config.ct0;
+  saveConfig(config);
+}
+
+/**
+ * Get the config file path (for display purposes).
+ */
+export function getConfigPath(): string {
+  return CONFIG_PATH;
+}

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,0 +1,21 @@
+/**
+ * Browser identifiers for cookie extraction.
+ * These match the browsers supported by sweet-cookie.
+ */
+export type BrowserId = "safari" | "chrome" | "brave" | "arc" | "firefox";
+
+/**
+ * xfeed configuration stored in ~/.config/xfeed/config.json
+ */
+export interface XfeedConfig {
+  /** Preferred browser for cookie extraction */
+  browser?: BrowserId;
+  /** Chrome/Chromium profile name (e.g., "Default", "Profile 1") */
+  chromeProfile?: string;
+  /** Firefox profile name */
+  firefoxProfile?: string;
+  /** Manually entered auth token */
+  authToken?: string;
+  /** Manually entered ct0 token */
+  ct0?: string;
+}


### PR DESCRIPTION
## Summary

Implement persistent authentication with browser selection on startup, token caching, and session expiration handling. Add support for Brave and Arc browsers alongside Chrome/Safari/Firefox. When session expires mid-TUI, a modal informs the user and exits cleanly (re-authentication requires restart, tracked in #98).

## Features

- **Browser detection & selection**: Detects installed browsers and prompts user on first run
- **Token persistence**: Saves auth tokens and browser preference to `~/.config/xfeed/config.json`
- **Manual token entry**: Users can paste tokens directly from DevTools
- **Session expiration detection**: TwitterClient detects 401/403 responses and notifies app
- **Enhanced browser support**: Chrome, Brave, Arc, Safari, Firefox via sweet-cookie
- **Startup auth recovery**: Full browser picker on auth failure (not just manual entry)
- **Clean TUI launches**: Screen cleared before rendering to remove auth flow output

## Known Issues

Terminal restoration after destroying OpenTUI renderer for readline prompts doesn't work cleanly (see #98). Current workaround: session expiration simply quits the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)