### PR TITLE
Rename all Twitter references to X (#84)

### DIFF
--- a/.claude/skills/bun-test/PATTERNS.md
+++ b/.claude/skills/bun-test/PATTERNS.md
@@ -2,7 +2,7 @@
 
 This file contains patterns specific to the xfeed codebase.
 
-## TwitterClient Test Pattern
+## XClient Test Pattern
 
 ```typescript
 // @ts-nocheck - Test file with fetch mocking
@@ -18,7 +18,7 @@ import {
   spyOn,
   type Mock,
 } from "bun:test";
-import { TwitterClient } from "./client";
+import { XClient } from "./client";
 import { runtimeQueryIds } from "./query-ids";
 
 // Mock implementations
@@ -53,7 +53,7 @@ const validCookies = {
   source: "test",
 };
 
-describe("TwitterClient", () => {
+describe("XClient", () => {
   beforeAll(() => {
     getQueryIdSpy = spyOn(runtimeQueryIds, "getQueryId").mockImplementation(mockGetQueryId);
     refreshSpy = spyOn(runtimeQueryIds, "refresh").mockImplementation(mockRefresh);
@@ -80,7 +80,7 @@ describe("TwitterClient", () => {
   });
 
   it("example test", async () => {
-    const client = new TwitterClient({ cookies: validCookies });
+    const client = new XClient({ cookies: validCookies });
     globalThis.fetch = mock(() => Promise.resolve(mockResponse({ data: {} })));
 
     const result = await client.someMethod();
@@ -191,7 +191,7 @@ describe("cookies", () => {
     mockImpl = () => Promise.resolve({ cookies: [], warnings: [] });
   });
 
-  it("extracts Twitter cookies", async () => {
+  it("extracts X cookies", async () => {
     setMockCookies([
       { name: "auth_token", value: "token123", domain: ".x.com" },
       { name: "ct0", value: "csrf456", domain: ".x.com" },
@@ -236,7 +236,7 @@ mock.module("./cookies", () => ({
 }));
 
 mock.module("@/api/client", () => ({
-  TwitterClient: class MockTwitterClient {
+  XClient: class MockXClient {
     getCurrentUser() { return mockGetCurrentUserImpl(); }
   },
 }));
@@ -288,7 +288,7 @@ For tests that require multiple fetch calls in sequence:
 
 ```typescript
 it("uploads video with polling", async () => {
-  const client = new TwitterClient({ cookies: validCookies });
+  const client = new XClient({ cookies: validCookies });
   let callCount = 0;
 
   globalThis.fetch = mock(() => {
@@ -325,7 +325,7 @@ it("uploads video with polling", async () => {
 
 ## GraphQL Response Patterns
 
-Twitter API responses have nested structures. Use these patterns:
+X API responses have nested structures. Use these patterns:
 
 ```typescript
 // Tweet response

--- a/.claude/skills/bun-test/SKILL.md
+++ b/.claude/skills/bun-test/SKILL.md
@@ -265,4 +265,4 @@ it("debugging", () => {
 
 ## Additional Resources
 
-For xfeed-specific patterns (TwitterClient, RuntimeQueryIdStore, cookie mocking, GraphQL responses), see [PATTERNS.md](PATTERNS.md).
+For xfeed-specific patterns (XClient, RuntimeQueryIdStore, cookie mocking, GraphQL responses), see [PATTERNS.md](PATTERNS.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-xfeed is a terminal-based X/Twitter viewer built with OpenTUI/React. It provides distraction-free browsing directly in the terminal with vim-style navigation.
+xfeed is a terminal-based X viewer built with OpenTUI/React. It provides distraction-free browsing directly in the terminal with vim-style navigation.
 
 ## Commands
 
@@ -48,8 +48,8 @@ PRs must reference a GitHub issue (e.g., `#123` or `Fixes #123`) in the title or
 src/
 ├── index.tsx          # CLI entry point (cac) → auth check → launch TUI
 ├── app.tsx            # Main OpenTUI app component
-├── api/               # Twitter GraphQL API (adapted from bird)
-│   ├── client.ts      # TwitterClient class
+├── api/               # X GraphQL API (adapted from bird)
+│   ├── client.ts      # XClient class
 │   ├── types.ts       # TweetData, UserData types
 │   ├── query-ids.ts   # GraphQL query ID management
 │   └── actions.ts     # Bookmark, Like mutations
@@ -72,12 +72,12 @@ type Result<T, E = string> = { ok: true; value: T } | { ok: false; error: E }
 
 **OpenTUI JSX**: Uses lowercase intrinsic elements (`<box>`, `<text>`, `<scrollbox>`) - NOT React DOM or Ink components. JSX is configured with `jsxImportSource: "@opentui/react"`.
 
-**Twitter API**: The API layer handles Twitter's undocumented GraphQL API with rotating query IDs. Query IDs are refreshed at runtime when they change.
+**X API**: The API layer handles X's undocumented GraphQL API with rotating query IDs. Query IDs are refreshed at runtime when they change.
 
 ### Reference Code
 
 The `.context/repos/` directory contains reference implementations:
-- `bird/` - CLI tool with TwitterClient implementation
+- `bird/` - CLI tool with XClient implementation
 - `opentui/` - OpenTUI framework (core + react)
 - `x-client-transaction-id/` - Transaction ID generator for API mutations (see `docs/x-client-transaction-id.md`)
 

--- a/conductor.json
+++ b/conductor.json
@@ -12,12 +12,12 @@
       {
         "name": "bird",
         "url": "https://github.com/steipete/bird",
-        "description": "Twitter API client reference implementation"
+        "description": "X API client reference implementation"
       },
       {
         "name": "x-client-transaction-id",
         "url": "https://github.com/Lqm1/x-client-transaction-id",
-        "description": "Transaction ID generator for Twitter API mutations"
+        "description": "Transaction ID generator for X API mutations"
       }
     ]
   }

--- a/docs/api-response-structure.md
+++ b/docs/api-response-structure.md
@@ -1,10 +1,10 @@
-# Twitter GraphQL API Response Structure
+# X GraphQL API Response Structure
 
-> **Note**: Twitter's GraphQL API is undocumented and unofficial. This documentation is based on reverse-engineering from the [steipete/bird](https://github.com/steipete/bird) project and observing real API responses.
+> **Note**: X's GraphQL API is undocumented and unofficial. This documentation is based on reverse-engineering from the [steipete/bird](https://github.com/steipete/bird) project and observing real API responses.
 
 ## Overview
 
-Twitter's web client uses an internal GraphQL API at `https://x.com/i/api/graphql/{queryId}/{operationName}`. Query IDs rotate periodically, requiring runtime refresh logic.
+X's web client uses an internal GraphQL API at `https://x.com/i/api/graphql/{queryId}/{operationName}`. Query IDs rotate periodically, requiring runtime refresh logic.
 
 ## Tweet Response Structure
 
@@ -150,7 +150,7 @@ The `quoteDepth` option controls parsing depth:
 
 ### Visibility Wrapper
 
-Sometimes Twitter wraps tweets in a visibility container:
+Sometimes X wraps tweets in a visibility container:
 
 ```json
 {

--- a/docs/x-client-transaction-id.md
+++ b/docs/x-client-transaction-id.md
@@ -1,12 +1,12 @@
 # x-client-transaction-id
 
-> Library for generating the `x-client-transaction-id` header required for Twitter/X API mutations.
+> Library for generating the `x-client-transaction-id` header required for X API mutations.
 
 ## Overview
 
-Twitter's API requires a cryptographically computed `x-client-transaction-id` header for mutation requests (like, bookmark, tweet, retweet). This header cannot be a random value - it must be derived from:
+X's API requires a cryptographically computed `x-client-transaction-id` header for mutation requests (like, bookmark, tweet, retweet). This header cannot be a random value - it must be derived from:
 
-1. The Twitter homepage HTML (contains verification key and animation SVG data)
+1. The X homepage HTML (contains verification key and animation SVG data)
 2. The HTTP method and API path
 3. Current timestamp
 4. A SHA-256 hash of the above combined with animation interpolation data
@@ -23,16 +23,16 @@ The library is vendored from [Lqm1/x-client-transaction-id](https://github.com/L
 bun add x-client-transaction-id
 ```
 
-### Usage in TwitterClient
+### Usage in XClient
 
 ```typescript
 import { ClientTransaction, handleXMigration } from "x-client-transaction-id";
 
-class TwitterClient {
+class XClient {
   private clientTransaction?: ClientTransaction;
   private transactionInitPromise?: Promise<void>;
 
-  // Lazy initialization - fetches Twitter homepage once
+  // Lazy initialization - fetches X homepage once
   private async ensureClientTransaction(): Promise<void> {
     if (this.clientTransaction) return;
     if (!this.transactionInitPromise) {
@@ -80,7 +80,7 @@ const document = await handleXMigration();
 ```
 
 This fetches `https://twitter.com/` (redirects to `x.com`) and parses the HTML. The document contains:
-- A `<meta name="twitter-site-verification">` tag with a base64-encoded key
+- A `<meta name="x-site-verification">` tag with a base64-encoded key
 - SVG animation frames in `<svg id="loading-x-anim-*">` elements
 - A reference to an "ondemand" JavaScript file with index values
 
@@ -89,7 +89,7 @@ This fetches `https://twitter.com/` (redirects to `x.com`) and parses the HTML. 
 The `ClientTransaction` class extracts:
 - **Key bytes**: From the site verification meta tag
 - **Animation data**: SVG path coordinates from loading animation frames
-- **Index values**: From Twitter's ondemand.js file (controls which animation frame/row to use)
+- **Index values**: From X's ondemand.js file (controls which animation frame/row to use)
 
 ### 3. Generate Animation Key
 
@@ -130,5 +130,5 @@ If initialization fails (network error, HTML structure changed), mutations will 
 ## References
 
 - [Lqm1/x-client-transaction-id](https://github.com/Lqm1/x-client-transaction-id) - Original library
-- [Twitter's ondemand.js](https://abs.twimg.com/responsive-web/client-web/) - Contains index values (rotates)
+- [X's ondemand.js](https://abs.twimg.com/responsive-web/client-web/) - Contains index values (rotates)
 - Browser DevTools - Inspect `x-client-transaction-id` header in mutation requests

--- a/scripts/test-api.ts
+++ b/scripts/test-api.ts
@@ -1,19 +1,19 @@
 #!/usr/bin/env bun
 /**
- * Manual test script for the Twitter API client
+ * Manual test script for the X API client
  * Run with: bun scripts/test-api.ts
  *
  * This will:
  * 1. Extract cookies from your browser (Safari/Chrome/Firefox)
- * 2. Create a TwitterClient
+ * 2. Create an XClient
  * 3. Test basic API calls
  */
 
-import { TwitterClient } from "../src/api/client";
+import { XClient } from "../src/api/client";
 import { resolveCredentials } from "../src/auth/cookies";
 
 async function main() {
-  console.log("🔐 Resolving Twitter credentials from browser...\n");
+  console.log("🔐 Resolving X credentials from browser...\n");
 
   const { cookies, warnings } = await resolveCredentials({});
 
@@ -32,7 +32,7 @@ async function main() {
 
   console.log(`✅ Got credentials from: ${cookies.source}\n`);
 
-  const client = new TwitterClient({ cookies });
+  const client = new XClient({ cookies });
 
   // Test 1: Get current user
   console.log("📋 Test 1: getCurrentUser()");

--- a/src/api/actions.ts
+++ b/src/api/actions.ts
@@ -1,7 +1,7 @@
 /**
  * Bookmark and Like action mutations
  *
- * The mutations are implemented in the TwitterClient class.
+ * The mutations are implemented in the XClient class.
  * This file re-exports the hook for convenient access.
  *
  * @see src/api/client.ts - likeTweet, unlikeTweet, createBookmark, deleteBookmark

--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck - Test file with complex mocking that conflicts with Bun's strict fetch types
 /**
- * Unit tests for TwitterClient
+ * Unit tests for XClient
  * Tests all public methods and edge cases for 100% coverage
  */
 
@@ -17,7 +17,7 @@ import {
   type Mock,
 } from "bun:test";
 
-import { TwitterClient } from "./client";
+import { XClient } from "./client";
 import { runtimeQueryIds } from "./query-ids";
 
 // Mock runtimeQueryIds
@@ -59,7 +59,7 @@ const validCookies = {
   source: "test",
 };
 
-describe("TwitterClient", () => {
+describe("XClient", () => {
   beforeAll(() => {
     // Create spies once for the entire test suite
     getQueryIdSpy = spyOn(runtimeQueryIds, "getQueryId").mockImplementation(
@@ -105,7 +105,7 @@ describe("TwitterClient", () => {
   describe("constructor", () => {
     it("throws if authToken is missing", () => {
       expect(() => {
-        new TwitterClient({
+        new XClient({
           cookies: {
             authToken: null,
             ct0: "test",
@@ -118,7 +118,7 @@ describe("TwitterClient", () => {
 
     it("throws if ct0 is missing", () => {
       expect(() => {
-        new TwitterClient({
+        new XClient({
           cookies: {
             authToken: "test",
             ct0: null,
@@ -130,12 +130,12 @@ describe("TwitterClient", () => {
     });
 
     it("creates client with valid cookies", () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       expect(client).toBeDefined();
     });
 
     it("uses provided userAgent", () => {
-      const client = new TwitterClient({
+      const client = new XClient({
         cookies: validCookies,
         userAgent: "CustomAgent/1.0",
       });
@@ -143,7 +143,7 @@ describe("TwitterClient", () => {
     });
 
     it("uses provided timeoutMs", () => {
-      const client = new TwitterClient({
+      const client = new XClient({
         cookies: validCookies,
         timeoutMs: 5000,
       });
@@ -151,7 +151,7 @@ describe("TwitterClient", () => {
     });
 
     it("builds cookieHeader from authToken and ct0 if not provided", () => {
-      const client = new TwitterClient({
+      const client = new XClient({
         cookies: {
           authToken: "abc",
           ct0: "xyz",
@@ -165,7 +165,7 @@ describe("TwitterClient", () => {
 
   describe("getTweet", () => {
     it("returns tweet on success", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       const tweetResponse = {
         data: {
           tweetResult: {
@@ -209,7 +209,7 @@ describe("TwitterClient", () => {
     });
 
     it("finds tweet in instructions if not in tweetResult", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       const tweetResponse = {
         data: {
           threaded_conversation_with_injections_v2: {
@@ -257,7 +257,7 @@ describe("TwitterClient", () => {
     });
 
     it("returns error on HTTP failure", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(mockResponse("Not found", { status: 500, ok: false }))
       );
@@ -270,7 +270,7 @@ describe("TwitterClient", () => {
     });
 
     it("returns error on GraphQL errors", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -284,7 +284,7 @@ describe("TwitterClient", () => {
     });
 
     it("returns error if tweet not found in response", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(mockResponse({ data: {} }))
       );
@@ -297,7 +297,7 @@ describe("TwitterClient", () => {
     });
 
     it("handles fetch exception", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() => Promise.reject(new Error("Network error")));
 
       const result = await client.getTweet("123456");
@@ -308,7 +308,7 @@ describe("TwitterClient", () => {
     });
 
     it("retries with refreshed query IDs on 404", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
 
       // All calls return 404 to test the failure case
       globalThis.fetch = mock(() =>
@@ -323,7 +323,7 @@ describe("TwitterClient", () => {
     });
 
     it("extracts article text when present", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       const tweetResponse = {
         data: {
           tweetResult: {
@@ -363,7 +363,7 @@ describe("TwitterClient", () => {
     });
 
     it("extracts note tweet text when present", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       const tweetResponse = {
         data: {
           tweetResult: {
@@ -401,7 +401,7 @@ describe("TwitterClient", () => {
     });
 
     it("handles article with title only, fetches from UserArticlesTweets", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       let callCount = 0;
 
       globalThis.fetch = mock(() => {
@@ -489,7 +489,7 @@ describe("TwitterClient", () => {
 
     it("handles debug article logging", async () => {
       process.env.XFEED_DEBUG_ARTICLE = "1";
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       const tweetResponse = {
         data: {
           tweetResult: {
@@ -522,7 +522,7 @@ describe("TwitterClient", () => {
 
   describe("tweet", () => {
     it("posts tweet successfully", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -545,7 +545,7 @@ describe("TwitterClient", () => {
     });
 
     it("posts tweet with media IDs", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -568,7 +568,7 @@ describe("TwitterClient", () => {
     });
 
     it("returns error on HTTP failure", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(mockResponse("Error", { status: 403, ok: false }))
       );
@@ -578,7 +578,7 @@ describe("TwitterClient", () => {
     });
 
     it("returns error on GraphQL errors", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -596,7 +596,7 @@ describe("TwitterClient", () => {
     });
 
     it("returns error if no tweet ID returned", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -613,7 +613,7 @@ describe("TwitterClient", () => {
     });
 
     it("retries on 404 and succeeds", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       let callCount = 0;
 
       globalThis.fetch = mock(() => {
@@ -641,7 +641,7 @@ describe("TwitterClient", () => {
     });
 
     it("falls back to status update on error 226", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       let callCount = 0;
 
       globalThis.fetch = mock(() => {
@@ -669,7 +669,7 @@ describe("TwitterClient", () => {
     });
 
     it("handles fetch exception", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.reject(new Error("Connection refused"))
       );
@@ -684,7 +684,7 @@ describe("TwitterClient", () => {
 
   describe("reply", () => {
     it("posts reply successfully", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -710,7 +710,7 @@ describe("TwitterClient", () => {
     });
 
     it("posts reply with media", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -734,7 +734,7 @@ describe("TwitterClient", () => {
 
   describe("search", () => {
     it("returns search results on success", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -787,7 +787,7 @@ describe("TwitterClient", () => {
     });
 
     it("returns error on HTTP failure", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(mockResponse("Error", { status: 500, ok: false }))
       );
@@ -797,7 +797,7 @@ describe("TwitterClient", () => {
     });
 
     it("returns error on GraphQL errors", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -811,7 +811,7 @@ describe("TwitterClient", () => {
     });
 
     it("retries on 404", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
 
       // All calls return 404 to test failure case
       globalThis.fetch = mock(() =>
@@ -826,7 +826,7 @@ describe("TwitterClient", () => {
     });
 
     it("handles fetch exception", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.reject(new Error("Network timeout"))
       );
@@ -836,7 +836,7 @@ describe("TwitterClient", () => {
     });
 
     it("uses custom count parameter", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -858,7 +858,7 @@ describe("TwitterClient", () => {
 
   describe("getCurrentUser", () => {
     it("returns user from settings endpoint", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -878,7 +878,7 @@ describe("TwitterClient", () => {
     });
 
     it("returns user from verify_credentials endpoint", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       let callCount = 0;
 
       globalThis.fetch = mock(() => {
@@ -902,7 +902,7 @@ describe("TwitterClient", () => {
     });
 
     it("returns user with nested user object", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -923,7 +923,7 @@ describe("TwitterClient", () => {
     });
 
     it("falls back to settings page HTML parsing", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       let callCount = 0;
 
       globalThis.fetch = mock(() => {
@@ -949,7 +949,7 @@ describe("TwitterClient", () => {
     });
 
     it("returns error when all endpoints fail", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(mockResponse("Error", { status: 401, ok: false }))
       );
@@ -959,7 +959,7 @@ describe("TwitterClient", () => {
     });
 
     it("handles JSON parse error gracefully", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       let callCount = 0;
 
       globalThis.fetch = mock(() => {
@@ -985,7 +985,7 @@ describe("TwitterClient", () => {
     });
 
     it("handles fetch exception", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() => Promise.reject(new Error("Network error")));
 
       const result = await client.getCurrentUser();
@@ -995,7 +995,7 @@ describe("TwitterClient", () => {
 
   describe("getReplies", () => {
     it("returns replies to a tweet", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -1047,7 +1047,7 @@ describe("TwitterClient", () => {
     });
 
     it("returns error on failure", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(mockResponse("Error", { status: 500, ok: false }))
       );
@@ -1059,7 +1059,7 @@ describe("TwitterClient", () => {
 
   describe("getThread", () => {
     it("returns full thread sorted by time", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -1141,7 +1141,7 @@ describe("TwitterClient", () => {
     });
 
     it("returns error on failure", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(mockResponse("Error", { status: 500, ok: false }))
       );
@@ -1153,7 +1153,7 @@ describe("TwitterClient", () => {
 
   describe("getBookmarks", () => {
     it("returns bookmarks on success", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -1204,7 +1204,7 @@ describe("TwitterClient", () => {
     });
 
     it("returns error on HTTP failure", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(mockResponse("Error", { status: 500, ok: false }))
       );
@@ -1214,7 +1214,7 @@ describe("TwitterClient", () => {
     });
 
     it("returns error on GraphQL errors", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -1228,7 +1228,7 @@ describe("TwitterClient", () => {
     });
 
     it("retries on 404", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
 
       // All calls return 404 to test failure case
       globalThis.fetch = mock(() =>
@@ -1243,7 +1243,7 @@ describe("TwitterClient", () => {
     });
 
     it("uses custom count parameter", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -1261,7 +1261,7 @@ describe("TwitterClient", () => {
     });
 
     it("handles fetch exception", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() => Promise.reject(new Error("Timeout")));
 
       const result = await client.getBookmarks();
@@ -1269,7 +1269,7 @@ describe("TwitterClient", () => {
     });
 
     it("accepts cursor parameter for pagination", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       let capturedUrl = "";
       globalThis.fetch = mock((url: string) => {
         capturedUrl = url;
@@ -1290,7 +1290,7 @@ describe("TwitterClient", () => {
     });
 
     it("returns nextCursor from response", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -1325,7 +1325,7 @@ describe("TwitterClient", () => {
     });
 
     it("returns undefined nextCursor when no cursor in response", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -1348,7 +1348,7 @@ describe("TwitterClient", () => {
 
   describe("getHomeTimeline", () => {
     it("returns home timeline on success", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -1399,7 +1399,7 @@ describe("TwitterClient", () => {
     });
 
     it("returns error on HTTP failure", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(mockResponse("Error", { status: 500, ok: false }))
       );
@@ -1409,7 +1409,7 @@ describe("TwitterClient", () => {
     });
 
     it("returns error on GraphQL errors", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -1423,7 +1423,7 @@ describe("TwitterClient", () => {
     });
 
     it("handles fetch exception", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() => Promise.reject(new Error("Network error")));
 
       const result = await client.getHomeTimeline();
@@ -1431,7 +1431,7 @@ describe("TwitterClient", () => {
     });
 
     it("uses custom count parameter", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -1449,7 +1449,7 @@ describe("TwitterClient", () => {
     });
 
     it("returns nextCursor from response", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -1508,7 +1508,7 @@ describe("TwitterClient", () => {
     });
 
     it("extracts cursor from TimelineReplaceEntry instruction", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -1571,7 +1571,7 @@ describe("TwitterClient", () => {
     });
 
     it("accepts cursor parameter for pagination", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       let capturedUrl = "";
       globalThis.fetch = mock((url: string) => {
         capturedUrl = url;
@@ -1592,7 +1592,7 @@ describe("TwitterClient", () => {
     });
 
     it("retries on 404 and succeeds", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       let callCount = 0;
 
       globalThis.fetch = mock(() => {
@@ -1648,7 +1648,7 @@ describe("TwitterClient", () => {
     });
 
     it("returns error after all query IDs return 404", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
 
       globalThis.fetch = mock(() =>
         Promise.resolve(mockResponse("Not found", { status: 404, ok: false }))
@@ -1664,7 +1664,7 @@ describe("TwitterClient", () => {
 
   describe("getHomeLatestTimeline", () => {
     it("returns latest timeline on success", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -1717,7 +1717,7 @@ describe("TwitterClient", () => {
     });
 
     it("returns error on HTTP failure", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(mockResponse("Error", { status: 500, ok: false }))
       );
@@ -1727,7 +1727,7 @@ describe("TwitterClient", () => {
     });
 
     it("returns error on GraphQL errors", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -1741,7 +1741,7 @@ describe("TwitterClient", () => {
     });
 
     it("handles fetch exception", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.reject(new Error("Connection error"))
       );
@@ -1751,7 +1751,7 @@ describe("TwitterClient", () => {
     });
 
     it("uses custom count parameter", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -1769,7 +1769,7 @@ describe("TwitterClient", () => {
     });
 
     it("returns nextCursor from response", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -1828,7 +1828,7 @@ describe("TwitterClient", () => {
     });
 
     it("accepts cursor parameter for pagination", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       let capturedUrl = "";
       globalThis.fetch = mock((url: string) => {
         capturedUrl = url;
@@ -1849,7 +1849,7 @@ describe("TwitterClient", () => {
     });
 
     it("retries on 404 and succeeds", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       let callCount = 0;
 
       // HomeLatestTimeline has only 1 unique query ID in tests (fallback == primary)
@@ -1907,7 +1907,7 @@ describe("TwitterClient", () => {
     });
 
     it("returns error after all query IDs return 404", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
 
       globalThis.fetch = mock(() =>
         Promise.resolve(mockResponse("Not found", { status: 404, ok: false }))
@@ -1923,7 +1923,7 @@ describe("TwitterClient", () => {
 
   describe("uploadMedia", () => {
     it("uploads image successfully", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       let callCount = 0;
 
       globalThis.fetch = mock(() => {
@@ -1953,7 +1953,7 @@ describe("TwitterClient", () => {
     });
 
     it("uploads GIF successfully", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(mockResponse({ media_id_string: "gif-123" }))
       );
@@ -1966,7 +1966,7 @@ describe("TwitterClient", () => {
     });
 
     it("uploads video successfully", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       let callCount = 0;
 
       globalThis.fetch = mock(() => {
@@ -1998,7 +1998,7 @@ describe("TwitterClient", () => {
     });
 
     it("polls for video processing when state is pending", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       let callCount = 0;
 
       globalThis.fetch = mock(() => {
@@ -2040,7 +2040,7 @@ describe("TwitterClient", () => {
     });
 
     it("returns error for unsupported media type", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
 
       const result = await client.uploadMedia({
         data: new Uint8Array([1, 2, 3]),
@@ -2051,7 +2051,7 @@ describe("TwitterClient", () => {
     });
 
     it("returns error on INIT failure", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(mockResponse("Error", { status: 400, ok: false }))
       );
@@ -2065,7 +2065,7 @@ describe("TwitterClient", () => {
     });
 
     it("returns error if INIT returns no media_id", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() => Promise.resolve(mockResponse({})));
 
       const result = await client.uploadMedia({
@@ -2077,7 +2077,7 @@ describe("TwitterClient", () => {
     });
 
     it("returns error on APPEND failure", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       let callCount = 0;
 
       globalThis.fetch = mock(() => {
@@ -2100,7 +2100,7 @@ describe("TwitterClient", () => {
     });
 
     it("returns error on FINALIZE failure", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       let callCount = 0;
 
       globalThis.fetch = mock(() => {
@@ -2126,7 +2126,7 @@ describe("TwitterClient", () => {
     });
 
     it("handles processing failure state", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       let callCount = 0;
 
       globalThis.fetch = mock(() => {
@@ -2158,7 +2158,7 @@ describe("TwitterClient", () => {
     });
 
     it("adds alt text for images", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       let callCount = 0;
 
       globalThis.fetch = mock(() => {
@@ -2181,7 +2181,7 @@ describe("TwitterClient", () => {
     });
 
     it("returns error on alt text failure", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       let callCount = 0;
 
       globalThis.fetch = mock(() => {
@@ -2205,7 +2205,7 @@ describe("TwitterClient", () => {
     });
 
     it("handles fetch exception", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() => Promise.reject(new Error("Upload failed")));
 
       const result = await client.uploadMedia({
@@ -2217,7 +2217,7 @@ describe("TwitterClient", () => {
     });
 
     it("handles chunked upload for large files", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       const largeData = new Uint8Array(10 * 1024 * 1024); // 10MB
       let appendCount = 0;
 
@@ -2250,7 +2250,7 @@ describe("TwitterClient", () => {
     });
 
     it("uses media_id when media_id_string is missing", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       let callCount = 0;
 
       globalThis.fetch = mock(() => {
@@ -2272,7 +2272,7 @@ describe("TwitterClient", () => {
 
   describe("timeout handling", () => {
     it("respects timeout setting", async () => {
-      const client = new TwitterClient({
+      const client = new XClient({
         cookies: validCookies,
         timeoutMs: 100,
       });
@@ -2290,7 +2290,7 @@ describe("TwitterClient", () => {
     });
 
     it("does not use timeout when set to 0", async () => {
-      const client = new TwitterClient({
+      const client = new XClient({
         cookies: validCookies,
         timeoutMs: 0,
       });
@@ -2306,7 +2306,7 @@ describe("TwitterClient", () => {
 
   describe("tweet result parsing edge cases", () => {
     it("handles tweet with core.screen_name instead of legacy.screen_name", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -2341,7 +2341,7 @@ describe("TwitterClient", () => {
     });
 
     it("handles tweet with missing text fields gracefully", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -2370,7 +2370,7 @@ describe("TwitterClient", () => {
     });
 
     it("handles items array in instructions via getThread", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -2430,7 +2430,7 @@ describe("TwitterClient", () => {
     });
 
     it("deduplicates tweets by ID", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -2506,7 +2506,7 @@ describe("TwitterClient", () => {
     });
 
     it("extracts favorited and bookmarked state from legacy", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -2543,7 +2543,7 @@ describe("TwitterClient", () => {
     });
 
     it("defaults favorited and bookmarked to false when missing", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -2578,7 +2578,7 @@ describe("TwitterClient", () => {
     });
 
     it("extracts partial interaction state (only favorited)", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -2616,7 +2616,7 @@ describe("TwitterClient", () => {
 
   describe("article text extraction edge cases", () => {
     it("extracts text from richtext field", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -2654,7 +2654,7 @@ describe("TwitterClient", () => {
     });
 
     it("extracts text from content.richtext field", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -2694,7 +2694,7 @@ describe("TwitterClient", () => {
     });
 
     it("collects text fields from nested article structure", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -2737,7 +2737,7 @@ describe("TwitterClient", () => {
 
   describe("status update fallback", () => {
     it("handles fallback with reply", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       let callCount = 0;
 
       globalThis.fetch = mock(() => {
@@ -2757,7 +2757,7 @@ describe("TwitterClient", () => {
     });
 
     it("returns combined error when fallback also fails", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       let callCount = 0;
 
       globalThis.fetch = mock(() => {
@@ -2785,7 +2785,7 @@ describe("TwitterClient", () => {
     });
 
     it("handles fallback HTTP error", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       let callCount = 0;
 
       globalThis.fetch = mock(() => {
@@ -2807,7 +2807,7 @@ describe("TwitterClient", () => {
     });
 
     it("handles fallback with media IDs", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       let callCount = 0;
 
       globalThis.fetch = mock(() => {
@@ -2830,7 +2830,7 @@ describe("TwitterClient", () => {
     });
 
     it("returns null from status update parsing if no text", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -2848,7 +2848,7 @@ describe("TwitterClient", () => {
 
   describe("URL extraction edge cases", () => {
     it("handles tweets with undefined expanded_url in entities", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -2890,7 +2890,7 @@ describe("TwitterClient", () => {
     });
 
     it("filters out urls with undefined expanded_url in timeline", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -2962,7 +2962,7 @@ describe("TwitterClient", () => {
     });
 
     it("handles media urls with undefined expanded_url", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -3026,7 +3026,7 @@ describe("TwitterClient", () => {
 
   describe("getNotifications", () => {
     it("returns notifications on success", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -3081,7 +3081,7 @@ describe("TwitterClient", () => {
     });
 
     it("returns error on HTTP failure", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(mockResponse("Error", { status: 500, ok: false }))
       );
@@ -3094,7 +3094,7 @@ describe("TwitterClient", () => {
     });
 
     it("returns error on GraphQL errors", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -3111,7 +3111,7 @@ describe("TwitterClient", () => {
     });
 
     it("retries on 404", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(mockResponse("Not found", { status: 404, ok: false }))
       );
@@ -3124,7 +3124,7 @@ describe("TwitterClient", () => {
     });
 
     it("uses custom count parameter", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       let capturedUrl = "";
       globalThis.fetch = mock((url: string) => {
         capturedUrl = url;
@@ -3151,7 +3151,7 @@ describe("TwitterClient", () => {
     });
 
     it("handles fetch exception", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.reject(new Error("Network timeout"))
       );
@@ -3164,7 +3164,7 @@ describe("TwitterClient", () => {
     });
 
     it("extracts unread sort index from instructions", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -3217,7 +3217,7 @@ describe("TwitterClient", () => {
     });
 
     it("extracts cursors from entries", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -3265,7 +3265,7 @@ describe("TwitterClient", () => {
     });
 
     it("handles empty instructions", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -3294,7 +3294,7 @@ describe("TwitterClient", () => {
     });
 
     it("handles undefined instructions", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({
@@ -3321,7 +3321,7 @@ describe("TwitterClient", () => {
     });
 
     it("uses fallback icon for unknown notification type", async () => {
-      const client = new TwitterClient({ cookies: validCookies });
+      const client = new XClient({ cookies: validCookies });
       globalThis.fetch = mock(() =>
         Promise.resolve(
           mockResponse({

--- a/src/api/runtime-query-ids.ts
+++ b/src/api/runtime-query-ids.ts
@@ -1,8 +1,8 @@
 /**
- * Runtime query ID management for Twitter GraphQL API
+ * Runtime query ID management for X GraphQL API
  * Adapted from bird reference implementation for xfeed
  *
- * Twitter's GraphQL query IDs rotate frequently. This module:
+ * X's GraphQL query IDs rotate frequently. This module:
  * 1. Caches discovered IDs to disk (~/.config/xfeed/query-ids-cache.json)
  * 2. Auto-discovers new IDs by scraping x.com client bundles
  * 3. Falls back to baked-in IDs if discovery fails

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,9 +1,9 @@
 /**
- * Twitter API types for xfeed
+ * X API types for xfeed
  * Consolidated from bird reference implementation
  */
 
-import type { TwitterCookies } from "@/auth/cookies";
+import type { XCookies } from "@/auth/cookies";
 
 /**
  * Result of a tweet creation operation
@@ -200,10 +200,10 @@ export interface CurrentUserResult {
 }
 
 /**
- * Options for creating a TwitterClient instance
+ * Options for creating an XClient instance
  */
-export interface TwitterClientOptions {
-  cookies: TwitterCookies;
+export interface XClientOptions {
+  cookies: XCookies;
   userAgent?: string;
   timeoutMs?: number;
   /** Max depth for quoted tweets (0 disables, default: 1) */
@@ -213,7 +213,7 @@ export interface TwitterClientOptions {
 }
 
 /**
- * Internal GraphQL tweet result structure from Twitter API responses
+ * Internal GraphQL tweet result structure from X API responses
  */
 export interface GraphqlTweetResult {
   __typename?: string;
@@ -457,7 +457,7 @@ export type FetchResult<T> =
  * User-friendly error messages for each error type
  */
 export const API_ERROR_MESSAGES: Record<ApiErrorType, string> = {
-  rate_limit: "Rate limited by Twitter. Please wait before trying again.",
+  rate_limit: "Rate limited by X. Please wait before trying again.",
   auth_expired: "Session expired. Please log into x.com and restart xfeed.",
   network_error: "Network error. Check your connection and try again.",
   not_found: "Content not found or has been deleted.",
@@ -480,7 +480,7 @@ export function isAuthError(errorType: ApiErrorType): boolean {
 }
 
 /**
- * Notification icon types from Twitter API
+ * Notification icon types from X API
  */
 export type NotificationIcon =
   | "heart_icon"
@@ -525,7 +525,7 @@ export type NotificationsResult =
   | { success: false; error: ApiError };
 
 /**
- * Internal notification timeline instruction types from Twitter API
+ * Internal notification timeline instruction types from X API
  */
 export interface NotificationInstruction {
   type: string;

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,7 +1,7 @@
 import { useKeyboard, useRenderer } from "@opentui/react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import type { TwitterClient } from "@/api/client";
+import type { XClient } from "@/api/client";
 import type { NotificationData, TweetData, UserData } from "@/api/types";
 
 import { ExitConfirmationModal } from "@/components/ExitConfirmationModal";
@@ -33,7 +33,7 @@ export type View =
 const MAIN_VIEWS = ["timeline", "bookmarks", "notifications"] as const;
 
 interface AppProps {
-  client: TwitterClient;
+  client: XClient;
   user: UserData;
 }
 

--- a/src/auth/browser-picker.ts
+++ b/src/auth/browser-picker.ts
@@ -44,7 +44,7 @@ export async function promptBrowserSelection(
         "\nNote: macOS will ask for keychain access. Click 'Always Allow' to avoid future prompts.\n"
       );
     }
-    console.log(`Using ${browsers[0].name} for Twitter cookies.\n`);
+    console.log(`Using ${browsers[0].name} for X cookies.\n`);
     return { ok: true, browser: browsers[0].id };
   }
 
@@ -69,7 +69,7 @@ export async function promptBrowserSelection(
       );
     }
 
-    console.log("Select browser to read Twitter cookies from:\n");
+    console.log("Select browser to read X cookies from:\n");
 
     for (let i = 0; i < browsers.length; i++) {
       const browser = browsers[i];

--- a/src/auth/check.test.preload.ts
+++ b/src/auth/check.test.preload.ts
@@ -7,11 +7,11 @@
 
 import { mock } from "bun:test";
 
-import type { TwitterCookies } from "./cookies";
+import type { XCookies } from "./cookies";
 
 // Export mutable mock implementations that tests can update
 export let mockResolveCredentialsImpl: (options: unknown) => Promise<{
-  cookies: TwitterCookies;
+  cookies: XCookies;
   warnings: string[];
 }> = () =>
   Promise.resolve({
@@ -35,7 +35,7 @@ export let mockGetCurrentUserImpl: () => Promise<{
   });
 
 export let lastClientOptions: {
-  cookies: TwitterCookies;
+  cookies: XCookies;
   timeoutMs?: number;
 } | null = null;
 
@@ -72,7 +72,7 @@ export function resetMocks() {
 }
 
 export function setLastClientOptions(
-  options: { cookies: TwitterCookies; timeoutMs?: number } | null
+  options: { cookies: XCookies; timeoutMs?: number } | null
 ) {
   lastClientOptions = options;
 }
@@ -83,8 +83,8 @@ mock.module("./cookies", () => ({
 }));
 
 mock.module("@/api/client", () => ({
-  TwitterClient: class MockTwitterClient {
-    constructor(options: { cookies: TwitterCookies; timeoutMs?: number }) {
+  XClient: class MockXClient {
+    constructor(options: { cookies: XCookies; timeoutMs?: number }) {
       lastClientOptions = options;
     }
     getCurrentUser() {

--- a/src/auth/check.test.ts
+++ b/src/auth/check.test.ts
@@ -12,7 +12,7 @@
 
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
-import type { TwitterCookies } from "./cookies";
+import type { XCookies } from "./cookies";
 
 import {
   lastClientOptions,
@@ -27,9 +27,7 @@ const { checkAuth, formatWarnings, getAuthErrorMessage } =
   await import("./check");
 
 // Helper to create valid cookies
-function createValidCookies(
-  overrides: Partial<TwitterCookies> = {}
-): TwitterCookies {
+function createValidCookies(overrides: Partial<XCookies> = {}): XCookies {
   return {
     authToken: "test-auth-token",
     ct0: "test-ct0",
@@ -249,7 +247,7 @@ describe("check", () => {
         });
       });
 
-      it("passes timeoutMs to TwitterClient", async () => {
+      it("passes timeoutMs to XClient", async () => {
         await checkAuth({ timeoutMs: 5000 });
 
         expect(lastClientOptions?.timeoutMs).toBe(5000);

--- a/src/auth/check.ts
+++ b/src/auth/check.ts
@@ -5,9 +5,9 @@
 
 import type { UserData } from "@/api/types";
 
-import { TwitterClient } from "@/api/client";
+import { XClient } from "@/api/client";
 
-import type { CookieSource, TwitterCookies } from "./cookies";
+import type { CookieSource, XCookies } from "./cookies";
 
 import { resolveCredentials } from "./cookies";
 
@@ -26,9 +26,9 @@ export type AuthErrorType =
 export type AuthCheckResult =
   | {
       ok: true;
-      client: TwitterClient;
+      client: XClient;
       user: UserData;
-      cookies: TwitterCookies;
+      cookies: XCookies;
       warnings: string[];
     }
   | {
@@ -136,7 +136,7 @@ export async function checkAuth(
   }
 
   // Step 3: Create the client
-  const client = new TwitterClient({
+  const client = new XClient({
     cookies,
     timeoutMs: options.timeoutMs,
   });

--- a/src/auth/cookies.ts
+++ b/src/auth/cookies.ts
@@ -1,11 +1,11 @@
 /**
- * Browser cookie extraction for Twitter authentication.
+ * Browser cookie extraction for X authentication.
  * Delegates to @steipete/sweet-cookie for Safari/Chrome/Firefox reads.
  */
 
 import { getCookies } from "@steipete/sweet-cookie";
 
-export interface TwitterCookies {
+export interface XCookies {
   authToken: string | null;
   ct0: string | null;
   cookieHeader: string | null;
@@ -13,7 +13,7 @@ export interface TwitterCookies {
 }
 
 export interface CookieExtractionResult {
-  cookies: TwitterCookies;
+  cookies: XCookies;
   warnings: string[];
 }
 
@@ -29,9 +29,9 @@ export type CookieSource =
   | "opera"
   | "firefox";
 
-const TWITTER_COOKIE_NAMES = ["auth_token", "ct0"] as const;
-const TWITTER_URL = "https://x.com/";
-const TWITTER_ORIGINS: string[] = ["https://x.com/", "https://twitter.com/"];
+const X_COOKIE_NAMES = ["auth_token", "ct0"] as const;
+const X_URL = "https://x.com/";
+const X_ORIGINS: string[] = ["https://x.com/", "https://twitter.com/"];
 
 function normalizeValue(value: unknown): string | null {
   if (typeof value !== "string") {
@@ -45,12 +45,12 @@ function cookieHeader(authToken: string, ct0: string): string {
   return `auth_token=${authToken}; ct0=${ct0}`;
 }
 
-function buildEmpty(): TwitterCookies {
+function buildEmpty(): XCookies {
   return { authToken: null, ct0: null, cookieHeader: null, source: null };
 }
 
 function readEnvCookie(
-  cookies: TwitterCookies,
+  cookies: XCookies,
   keys: readonly string[],
   field: "authToken" | "ct0"
 ): void {
@@ -101,7 +101,7 @@ function labelForSource(source: CookieSource, profile?: string): string {
 
 function pickCookieValue(
   cookies: Array<{ name?: string; value?: string; domain?: string }>,
-  name: (typeof TWITTER_COOKIE_NAMES)[number]
+  name: (typeof X_COOKIE_NAMES)[number]
 ): string | null {
   const matches = cookies.filter(
     (c) => c?.name === name && typeof c.value === "string"
@@ -164,7 +164,7 @@ function getChromiumBrowser(
   }
 }
 
-async function readTwitterCookiesFromBrowser(options: {
+async function readXCookiesFromBrowser(options: {
   source: CookieSource;
   chromeProfile?: string;
   firefoxProfile?: string;
@@ -176,9 +176,9 @@ async function readTwitterCookiesFromBrowser(options: {
   const chromiumBrowser = getChromiumBrowser(options.source);
 
   const { cookies, warnings: providerWarnings } = await getCookies({
-    url: TWITTER_URL,
-    origins: TWITTER_ORIGINS,
-    names: [...TWITTER_COOKIE_NAMES],
+    url: X_URL,
+    origins: X_ORIGINS,
+    names: [...X_COOKIE_NAMES],
     browsers: [browser],
     mode: "merge",
     chromeProfile: options.chromeProfile,
@@ -207,20 +207,20 @@ async function readTwitterCookiesFromBrowser(options: {
 
   const browserName = labelForSource(options.source);
   warnings.push(
-    `No Twitter cookies found in ${browserName}. Make sure you are logged into x.com in ${browserName}.`
+    `No X cookies found in ${browserName}. Make sure you are logged into x.com in ${browserName}.`
   );
 
   return { cookies: out, warnings };
 }
 
 export async function extractCookiesFromSafari(): Promise<CookieExtractionResult> {
-  return readTwitterCookiesFromBrowser({ source: "safari" });
+  return readXCookiesFromBrowser({ source: "safari" });
 }
 
 export async function extractCookiesFromChrome(
   profile?: string
 ): Promise<CookieExtractionResult> {
-  return readTwitterCookiesFromBrowser({
+  return readXCookiesFromBrowser({
     source: "chrome",
     chromeProfile: profile,
   });
@@ -229,14 +229,14 @@ export async function extractCookiesFromChrome(
 export async function extractCookiesFromFirefox(
   profile?: string
 ): Promise<CookieExtractionResult> {
-  return readTwitterCookiesFromBrowser({
+  return readXCookiesFromBrowser({
     source: "firefox",
     firefoxProfile: profile,
   });
 }
 
 /**
- * Resolve Twitter credentials from multiple sources.
+ * Resolve X credentials from multiple sources.
  * Priority: CLI args > environment variables > browsers (ordered).
  */
 export async function resolveCredentials(options: {
@@ -270,7 +270,7 @@ export async function resolveCredentials(options: {
 
   const sourcesToTry = resolveSources(options.cookieSource);
   for (const source of sourcesToTry) {
-    const res = await readTwitterCookiesFromBrowser({
+    const res = await readXCookiesFromBrowser({
       source,
       chromeProfile: options.chromeProfile,
       firefoxProfile: options.firefoxProfile,

--- a/src/components/FolderPicker.tsx
+++ b/src/components/FolderPicker.tsx
@@ -8,7 +8,7 @@
 import { useKeyboard } from "@opentui/react";
 import { useEffect, useState } from "react";
 
-import type { TwitterClient } from "@/api/client";
+import type { XClient } from "@/api/client";
 import type { TweetData } from "@/api/types";
 
 import { useBookmarkFolders } from "@/hooks/useBookmarkFolders";
@@ -17,7 +17,7 @@ import { useListNavigation } from "@/hooks/useListNavigation";
 const X_BLUE = "#1DA1F2";
 
 interface FolderPickerProps {
-  client: TwitterClient;
+  client: XClient;
   /** The tweet being moved */
   tweet: TweetData;
   /** Called when a folder is selected */

--- a/src/hooks/useActions.ts
+++ b/src/hooks/useActions.ts
@@ -6,11 +6,11 @@
 
 import { useState, useCallback } from "react";
 
-import type { TwitterClient } from "@/api/client";
+import type { XClient } from "@/api/client";
 import type { TweetData } from "@/api/types";
 
 export interface UseActionsOptions {
-  client: TwitterClient;
+  client: XClient;
   /** Callback when an action fails - use to show error message */
   onError?: (error: string) => void;
   /** Callback when an action succeeds - use to show success message */

--- a/src/hooks/useBookmarkFolders.ts
+++ b/src/hooks/useBookmarkFolders.ts
@@ -4,11 +4,11 @@
 
 import { useState, useEffect, useCallback } from "react";
 
-import type { TwitterClient } from "@/api/client";
+import type { XClient } from "@/api/client";
 import type { BookmarkFolder } from "@/api/types";
 
 export interface UseBookmarkFoldersOptions {
-  client: TwitterClient;
+  client: XClient;
   /** Whether to fetch folders on mount (default: true) */
   enabled?: boolean;
 }

--- a/src/hooks/useBookmarks.ts
+++ b/src/hooks/useBookmarks.ts
@@ -5,11 +5,11 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 
-import type { TwitterClient } from "@/api/client";
+import type { XClient } from "@/api/client";
 import type { ApiError, TweetData } from "@/api/types";
 
 export interface UseBookmarksOptions {
-  client: TwitterClient;
+  client: XClient;
 }
 
 export interface UseBookmarksResult {

--- a/src/hooks/useNotifications.test.ts
+++ b/src/hooks/useNotifications.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, expect, it, mock } from "bun:test";
 
-import type { TwitterClient } from "@/api/client";
+import type { XClient } from "@/api/client";
 import type {
   ApiError,
   NotificationData,
@@ -16,10 +16,10 @@ import type {
 // We test the core logic directly rather than React integration
 function createMockClient(
   getNotificationsResult: NotificationsResult
-): TwitterClient {
+): XClient {
   return {
     getNotifications: mock(() => Promise.resolve(getNotificationsResult)),
-  } as unknown as TwitterClient;
+  } as unknown as XClient;
 }
 
 function createNotification(

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -5,11 +5,11 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import type { TwitterClient } from "@/api/client";
+import type { XClient } from "@/api/client";
 import type { ApiError, NotificationData } from "@/api/types";
 
 export interface UseNotificationsOptions {
-  client: TwitterClient;
+  client: XClient;
 }
 
 export interface UseNotificationsResult {

--- a/src/hooks/usePostDetail.ts
+++ b/src/hooks/usePostDetail.ts
@@ -5,12 +5,12 @@
 
 import { useState, useEffect, useCallback } from "react";
 
-import type { TwitterClient } from "@/api/client";
+import type { XClient } from "@/api/client";
 import type { TweetData } from "@/api/types";
 
 export interface UsePostDetailOptions {
-  /** Twitter API client */
-  client: TwitterClient;
+  /** X API client */
+  client: XClient;
   /** Initial tweet data (passed from timeline for immediate display) */
   tweet: TweetData;
 }

--- a/src/hooks/useThread.prototype.ts
+++ b/src/hooks/useThread.prototype.ts
@@ -9,7 +9,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 
-import type { TwitterClient } from "@/api/client";
+import type { XClient } from "@/api/client";
 import type { TweetData } from "@/api/types";
 
 import {
@@ -18,7 +18,7 @@ import {
 } from "@/components/ThreadView.prototype";
 
 export interface UseThreadOptions {
-  client: TwitterClient;
+  client: XClient;
   tweet: TweetData;
   /** Maximum depth of ancestor chain to fetch (default: 10) */
   maxAncestorDepth?: number;
@@ -47,7 +47,7 @@ export interface UseThreadResult {
  * Fetch the chain of ancestor tweets
  */
 async function fetchAncestorChain(
-  client: TwitterClient,
+  client: XClient,
   startTweet: TweetData,
   maxDepth: number
 ): Promise<{ ancestors: TweetData[]; error: string | null }> {

--- a/src/hooks/useTimeline.ts
+++ b/src/hooks/useTimeline.ts
@@ -6,13 +6,13 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 
-import type { TwitterClient } from "@/api/client";
+import type { XClient } from "@/api/client";
 import type { ApiError, TweetData } from "@/api/types";
 
 export type TimelineTab = "for_you" | "following";
 
 export interface UseTimelineOptions {
-  client: TwitterClient;
+  client: XClient;
   initialTab?: TimelineTab;
 }
 

--- a/src/hooks/useUserProfile.ts
+++ b/src/hooks/useUserProfile.ts
@@ -4,11 +4,11 @@
 
 import { useState, useEffect, useCallback } from "react";
 
-import type { TwitterClient } from "@/api/client";
+import type { XClient } from "@/api/client";
 import type { TweetData, UserProfileData } from "@/api/types";
 
 export interface UseUserProfileOptions {
-  client: TwitterClient;
+  client: XClient;
   username: string;
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,8 +29,8 @@ const VALID_BROWSERS: BrowserId[] = [
 
 cli
   .command("", "Launch xfeed TUI")
-  .option("--auth-token <token>", "Twitter auth_token cookie")
-  .option("--ct0 <token>", "Twitter ct0 cookie (CSRF token)")
+  .option("--auth-token <token>", "X auth_token cookie")
+  .option("--ct0 <token>", "X ct0 cookie (CSRF token)")
   .option(
     "--browser <browser>",
     "Browser to read cookies from (safari, chrome, brave, arc, firefox)"

--- a/src/lib/media.ts
+++ b/src/lib/media.ts
@@ -10,7 +10,7 @@ import { join, extname } from "node:path";
 import type { MediaItem, UrlEntity } from "@/api/types";
 
 /**
- * Default headers for fetching media from Twitter CDN
+ * Default headers for fetching media from X CDN
  * Helps avoid 403 errors from hotlinking protection
  */
 const MEDIA_FETCH_HEADERS = {

--- a/src/screens/BookmarksScreen.tsx
+++ b/src/screens/BookmarksScreen.tsx
@@ -6,7 +6,7 @@
 import { useKeyboard } from "@opentui/react";
 import { useEffect } from "react";
 
-import type { TwitterClient } from "@/api/client";
+import type { XClient } from "@/api/client";
 import type { TweetData } from "@/api/types";
 import type { TweetActionState } from "@/hooks/useActions";
 
@@ -15,7 +15,7 @@ import { PostList } from "@/components/PostList";
 import { useBookmarks } from "@/hooks/useBookmarks";
 
 interface BookmarksScreenProps {
-  client: TwitterClient;
+  client: XClient;
   focused?: boolean;
   onPostCountChange?: (count: number) => void;
   onPostSelect?: (post: TweetData) => void;

--- a/src/screens/NotificationsScreen.tsx
+++ b/src/screens/NotificationsScreen.tsx
@@ -6,7 +6,7 @@
 import { useKeyboard } from "@opentui/react";
 import { useEffect } from "react";
 
-import type { TwitterClient } from "@/api/client";
+import type { XClient } from "@/api/client";
 import type { NotificationData } from "@/api/types";
 
 import { ErrorBanner } from "@/components/ErrorBanner";
@@ -14,7 +14,7 @@ import { NotificationList } from "@/components/NotificationList";
 import { useNotifications } from "@/hooks/useNotifications";
 
 interface NotificationsScreenProps {
-  client: TwitterClient;
+  client: XClient;
   focused?: boolean;
   onNotificationCountChange?: (count: number) => void;
   onUnreadCountChange?: (count: number) => void;

--- a/src/screens/PostDetailScreen.tsx
+++ b/src/screens/PostDetailScreen.tsx
@@ -8,7 +8,7 @@ import type { ScrollBoxRenderable } from "@opentui/core";
 import { useKeyboard } from "@opentui/react";
 import { useState, useRef, useEffect, useCallback } from "react";
 
-import type { TwitterClient } from "@/api/client";
+import type { XClient } from "@/api/client";
 import type { TweetData } from "@/api/types";
 
 import { PostCard } from "@/components/PostCard";
@@ -63,8 +63,8 @@ function findChildById(
 const MAX_TRUNCATED_LINES = 10;
 
 interface PostDetailScreenProps {
-  /** Twitter API client for fetching thread data */
-  client: TwitterClient;
+  /** X API client for fetching thread data */
+  client: XClient;
   tweet: TweetData;
   focused?: boolean;
   onBack?: () => void;

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -6,7 +6,7 @@
 import { useKeyboard } from "@opentui/react";
 import { useState, useCallback } from "react";
 
-import type { TwitterClient } from "@/api/client";
+import type { XClient } from "@/api/client";
 import type { TweetData } from "@/api/types";
 import type { TweetActionState } from "@/hooks/useActions";
 
@@ -18,7 +18,7 @@ import { openInBrowser, previewImageUrl } from "@/lib/media";
 const X_BLUE = "#1DA1F2";
 
 /**
- * Format Twitter's created_at date to "Joined Month Year"
+ * Format X's created_at date to "Joined Month Year"
  */
 function formatJoinDate(createdAt: string | undefined): string | undefined {
   if (!createdAt) return undefined;
@@ -47,7 +47,7 @@ function extractDomain(url: string | undefined): string | undefined {
 }
 
 interface ProfileScreenProps {
-  client: TwitterClient;
+  client: XClient;
   username: string;
   focused?: boolean;
   onBack?: () => void;

--- a/src/screens/ThreadScreen.tsx
+++ b/src/screens/ThreadScreen.tsx
@@ -7,14 +7,14 @@
  * @experimental
  */
 
-import type { TwitterClient } from "@/api/client";
+import type { XClient } from "@/api/client";
 import type { TweetData } from "@/api/types";
 
 import { ThreadViewPrototype } from "@/components/ThreadView.prototype";
 import { useThread } from "@/hooks/useThread.prototype";
 
 interface ThreadScreenProps {
-  client: TwitterClient;
+  client: XClient;
   tweet: TweetData;
   focused?: boolean;
   onBack?: () => void;

--- a/src/screens/TimelineScreen.tsx
+++ b/src/screens/TimelineScreen.tsx
@@ -6,7 +6,7 @@
 import { useKeyboard } from "@opentui/react";
 import { useEffect } from "react";
 
-import type { TwitterClient } from "@/api/client";
+import type { XClient } from "@/api/client";
 import type { TweetData } from "@/api/types";
 import type { TweetActionState } from "@/hooks/useActions";
 
@@ -15,7 +15,7 @@ import { PostList } from "@/components/PostList";
 import { useTimeline, type TimelineTab } from "@/hooks/useTimeline";
 
 interface TimelineScreenProps {
-  client: TwitterClient;
+  client: XClient;
   focused?: boolean;
   onPostCountChange?: (count: number) => void;
   onPostSelect?: (post: TweetData) => void;


### PR DESCRIPTION
## Summary

Comprehensive rebranding from "Twitter" to "X" across the entire codebase, addressing issue #84. Updated user-facing text, documentation, code comments, and internal naming (classes, types, constants).

## Key Changes

- Classes: `TwitterClient` → `XClient`, `TwitterCookies` → `XCookies`
- Types: `TwitterClientOptions` → `XClientOptions`
- Constants: `TWITTER_API_BASE` → `X_API_BASE`, etc.
- Documentation and comments updated throughout
- Test files and skill documentation updated for consistency

## Preserved (intentionally)

Domain names (twitter.com, api.twitter.com) and API parameters (x-twitter-* headers, responsive_web_twitter_* flags) remain unchanged as they're required for proper API functionality.

🤖 Generated with Claude Code