### PR TITLE
refactor: Centralize color constants into src/lib/colors.ts

### DIFF
--- a/src/components/ErrorBanner.tsx
+++ b/src/components/ErrorBanner.tsx
@@ -7,6 +7,8 @@ import { useState, useEffect } from "react";
 
 import type { ApiError, ApiErrorType } from "@/api/types";
 
+import { colors } from "@/lib/colors";
+
 interface ErrorBannerProps {
   /** The error to display */
   error: ApiError;
@@ -147,7 +149,7 @@ export function ErrorBanner({
       </box>
       {actionHint && (
         <box style={{ paddingTop: 1, paddingLeft: 4 }}>
-          <text fg="#888888">{actionHint}</text>
+          <text fg={colors.muted}>{actionHint}</text>
         </box>
       )}
     </box>
@@ -179,10 +181,10 @@ export function OfflineIndicator() {
         flexDirection: "row",
       }}
     >
-      <text fg="#ffaa00">
+      <text fg={colors.warning}>
         <b>[~]</b>{" "}
       </text>
-      <text fg="#888888">Offline - Check your connection</text>
+      <text fg={colors.muted}>Offline - Check your connection</text>
     </box>
   );
 }

--- a/src/components/ExitConfirmationModal.tsx
+++ b/src/components/ExitConfirmationModal.tsx
@@ -8,7 +8,7 @@
 import { useKeyboard } from "@opentui/react";
 import { useState } from "react";
 
-const X_BLUE = "#1DA1F2";
+import { colors } from "@/lib/colors";
 
 interface ExitConfirmationModalProps {
   /** Called when user confirms exit (y or Enter on Yes) */
@@ -89,24 +89,24 @@ export function ExitConfirmationModal({
           backgroundColor="#000000"
         >
           <box style={{ paddingBottom: 1 }}>
-            <text fg={X_BLUE}>Exit xfeed?</text>
+            <text fg={colors.primary}>Exit xfeed?</text>
           </box>
 
           <box style={{ flexDirection: "row" }}>
-            <text fg={selectedIndex === 0 ? X_BLUE : "#888888"}>
+            <text fg={selectedIndex === 0 ? colors.primary : colors.muted}>
               {selectedIndex === 0 ? "> " : "  "}Yes
             </text>
           </box>
           <box style={{ flexDirection: "row" }}>
-            <text fg={selectedIndex === 1 ? X_BLUE : "#888888"}>
+            <text fg={selectedIndex === 1 ? colors.primary : colors.muted}>
               {selectedIndex === 1 ? "> " : "  "}No
             </text>
           </box>
 
           <box style={{ paddingTop: 1, flexDirection: "row" }}>
-            <text fg="#666666">y</text>
+            <text fg={colors.dim}>y</text>
             <text fg="#444444"> yes </text>
-            <text fg="#666666">n/Esc</text>
+            <text fg={colors.dim}>n/Esc</text>
             <text fg="#444444"> no</text>
           </box>
         </box>

--- a/src/components/FolderPicker.tsx
+++ b/src/components/FolderPicker.tsx
@@ -13,8 +13,7 @@ import type { TweetData } from "@/api/types";
 
 import { useBookmarkFolders } from "@/hooks/useBookmarkFolders";
 import { useListNavigation } from "@/hooks/useListNavigation";
-
-const X_BLUE = "#1DA1F2";
+import { colors } from "@/lib/colors";
 
 interface FolderPickerProps {
   client: XClient;
@@ -103,11 +102,11 @@ export function FolderPicker({
             backgroundColor="#000000"
           >
             <box style={{ paddingBottom: 1 }}>
-              <text fg={X_BLUE}>Move to folder</text>
+              <text fg={colors.primary}>Move to folder</text>
             </box>
-            <text fg="#888888">Loading folders...</text>
+            <text fg={colors.muted}>Loading folders...</text>
             <box style={{ paddingTop: 1 }}>
-              <text fg="#666666">Esc</text>
+              <text fg={colors.dim}>Esc</text>
               <text fg="#444444"> cancel</text>
             </box>
           </box>
@@ -139,17 +138,17 @@ export function FolderPicker({
           <box
             style={{
               borderStyle: "rounded",
-              borderColor: "#E0245E",
+              borderColor: colors.error,
               padding: 1,
             }}
             backgroundColor="#000000"
           >
             <box style={{ paddingBottom: 1 }}>
-              <text fg={X_BLUE}>Move to folder</text>
+              <text fg={colors.primary}>Move to folder</text>
             </box>
-            <text fg="#E0245E">Error: {error}</text>
+            <text fg={colors.error}>Error: {error}</text>
             <box style={{ paddingTop: 1 }}>
-              <text fg="#666666">Esc</text>
+              <text fg={colors.dim}>Esc</text>
               <text fg="#444444"> close</text>
             </box>
           </box>
@@ -187,12 +186,12 @@ export function FolderPicker({
             backgroundColor="#000000"
           >
             <box style={{ paddingBottom: 1 }}>
-              <text fg={X_BLUE}>Move to folder</text>
+              <text fg={colors.primary}>Move to folder</text>
             </box>
-            <text fg="#888888">No folders yet.</text>
-            <text fg="#666666">Create folders on x.com</text>
+            <text fg={colors.muted}>No folders yet.</text>
+            <text fg={colors.dim}>Create folders on x.com</text>
             <box style={{ paddingTop: 1 }}>
-              <text fg="#666666">Esc</text>
+              <text fg={colors.dim}>Esc</text>
               <text fg="#444444"> close</text>
             </box>
           </box>
@@ -237,13 +236,13 @@ export function FolderPicker({
           backgroundColor="#000000"
         >
           <box style={{ paddingBottom: 1, flexDirection: "row" }}>
-            <text fg={X_BLUE}>Move to folder</text>
-            <text fg="#666666"> ({folders.length} folders)</text>
+            <text fg={colors.primary}>Move to folder</text>
+            <text fg={colors.dim}> ({folders.length} folders)</text>
           </box>
 
           {hasMoreAbove ? (
             <box style={{ flexDirection: "row" }}>
-              <text fg="#666666"> ↑ more</text>
+              <text fg={colors.dim}> ↑ more</text>
             </box>
           ) : null}
 
@@ -252,7 +251,7 @@ export function FolderPicker({
             const isSelected = actualIndex === selectedIndex;
             return (
               <box key={folder.id} style={{ flexDirection: "row" }}>
-                <text fg={isSelected ? X_BLUE : "#888888"}>
+                <text fg={isSelected ? colors.primary : colors.muted}>
                   {isSelected ? "> " : "  "}
                   {folder.name}
                 </text>
@@ -262,16 +261,16 @@ export function FolderPicker({
 
           {hasMoreBelow ? (
             <box style={{ flexDirection: "row" }}>
-              <text fg="#666666"> ↓ more</text>
+              <text fg={colors.dim}> ↓ more</text>
             </box>
           ) : null}
 
           <box style={{ paddingTop: 1, flexDirection: "row" }}>
-            <text fg="#666666">j/k</text>
+            <text fg={colors.dim}>j/k</text>
             <text fg="#444444"> nav </text>
-            <text fg="#666666">Enter</text>
+            <text fg={colors.dim}>Enter</text>
             <text fg="#444444"> select </text>
-            <text fg="#666666">Esc</text>
+            <text fg={colors.dim}>Esc</text>
             <text fg="#444444"> cancel</text>
           </box>
         </box>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,7 @@
 import { useTerminalDimensions } from "@opentui/react";
 
+import { colors } from "@/lib/colors";
+
 type Shortcut = { key: string; label: string };
 
 const SHORTCUTS: Shortcut[] = [
@@ -17,7 +19,7 @@ function ShortcutItem({ shortcut }: { shortcut: Shortcut }) {
   return (
     <box style={{ flexDirection: "row", flexShrink: 0 }}>
       <text fg="#ffffff">{shortcut.key}</text>
-      <text fg="#666666"> {shortcut.label}</text>
+      <text fg={colors.dim}> {shortcut.label}</text>
     </box>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,7 @@
 import type { View } from "@/app";
 
+import { colors } from "@/lib/colors";
+
 interface HeaderProps {
   currentView: View;
   postCount?: number;
@@ -33,14 +35,14 @@ export function Header({
         flexDirection: "row",
       }}
     >
-      <text fg="#1DA1F2">xfeed</text>
+      <text fg={colors.primary}>xfeed</text>
       {unreadNotificationCount !== undefined && unreadNotificationCount > 0 && (
-        <text fg="#E0245E"> ({unreadNotificationCount})</text>
+        <text fg={colors.error}> ({unreadNotificationCount})</text>
       )}
-      <text fg="#666666"> | </text>
+      <text fg={colors.dim}> | </text>
       <text fg="#ffffff">{viewLabel}</text>
       {postCount !== undefined && postCount > 0 && (
-        <text fg="#666666"> ({getCountLabel(currentView, postCount)})</text>
+        <text fg={colors.dim}> ({getCountLabel(currentView, postCount)})</text>
       )}
     </box>
   );

--- a/src/components/NotificationItem.tsx
+++ b/src/components/NotificationItem.tsx
@@ -4,19 +4,18 @@
 
 import type { NotificationData, NotificationIcon } from "@/api/types";
 
+import { colors } from "@/lib/colors";
 import { formatRelativeTime, truncateText } from "@/lib/format";
-
-const SELECTED_BG = "#1a1a2e";
 
 const ICON_MAP: Record<
   NotificationIcon,
   { symbol: string; color: string; label: string }
 > = {
-  heart_icon: { symbol: "\u2665", color: "#E0245E", label: "like" },
-  person_icon: { symbol: "\u2603", color: "#1DA1F2", label: "follow" },
+  heart_icon: { symbol: "\u2665", color: colors.error, label: "like" },
+  person_icon: { symbol: "\u2603", color: colors.primary, label: "follow" },
   bird_icon: { symbol: "\u2699", color: "#794BC4", label: "system" },
-  retweet_icon: { symbol: "\u21BB", color: "#17BF63", label: "repost" },
-  reply_icon: { symbol: "\u21A9", color: "#1DA1F2", label: "reply" },
+  retweet_icon: { symbol: "\u21BB", color: colors.success, label: "repost" },
+  reply_icon: { symbol: "\u21A9", color: colors.primary, label: "reply" },
 };
 
 interface NotificationItemProps {
@@ -32,7 +31,7 @@ export function NotificationItem({
 }: NotificationItemProps) {
   const iconInfo = ICON_MAP[notification.icon] ?? {
     symbol: "?",
-    color: "#888888",
+    color: colors.muted,
     label: "notification",
   };
   const timeAgo = formatRelativeTime(notification.timestamp);
@@ -46,7 +45,7 @@ export function NotificationItem({
         paddingLeft: 1,
         paddingRight: 1,
         paddingTop: 1,
-        backgroundColor: isSelected ? SELECTED_BG : undefined,
+        backgroundColor: isSelected ? colors.selectedBg : undefined,
       }}
     >
       {/* Icon and message line */}
@@ -54,13 +53,13 @@ export function NotificationItem({
         <text fg={iconInfo.color}>{isSelected ? "> " : "  "}</text>
         <text fg={iconInfo.color}>{iconInfo.symbol} </text>
         <text fg="#ffffff">{notification.message}</text>
-        {timeAgo && <text fg="#666666"> · {timeAgo}</text>}
+        {timeAgo && <text fg={colors.dim}> · {timeAgo}</text>}
       </box>
 
       {/* Show tweet preview if available */}
       {notification.targetTweet && (
         <box style={{ paddingLeft: 4, marginTop: 1 }}>
-          <text fg="#888888">
+          <text fg={colors.muted}>
             "{truncateText(notification.targetTweet.text, 2, 70)}"
           </text>
         </box>
@@ -71,7 +70,7 @@ export function NotificationItem({
         notification.fromUsers &&
         notification.fromUsers.length > 0 && (
           <box style={{ paddingLeft: 4, marginTop: 1 }}>
-            <text fg="#666666">
+            <text fg={colors.dim}>
               @{notification.fromUsers[0]?.username ?? "unknown"}
             </text>
           </box>

--- a/src/components/NotificationList.tsx
+++ b/src/components/NotificationList.tsx
@@ -10,6 +10,7 @@ import type { NotificationData } from "@/api/types";
 
 import { NotificationItem } from "@/components/NotificationItem";
 import { useListNavigation } from "@/hooks/useListNavigation";
+import { colors } from "@/lib/colors";
 
 interface NotificationListProps {
   notifications: NotificationData[];
@@ -119,7 +120,7 @@ export function NotificationList({
   if (notifications.length === 0) {
     return (
       <box style={{ padding: 2 }}>
-        <text fg="#888888">No notifications</text>
+        <text fg={colors.muted}>No notifications</text>
       </box>
     );
   }
@@ -143,12 +144,12 @@ export function NotificationList({
       ))}
       {loadingMore ? (
         <box style={{ padding: 1, paddingLeft: 2 }}>
-          <text fg="#888888">Loading more...</text>
+          <text fg={colors.muted}>Loading more...</text>
         </box>
       ) : null}
       {!hasMore && notifications.length > 0 ? (
         <box style={{ padding: 1, paddingLeft: 2 }}>
-          <text fg="#666666">No more notifications</text>
+          <text fg={colors.dim}>No more notifications</text>
         </box>
       ) : null}
     </scrollbox>

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -4,15 +4,12 @@
 
 import type { TweetData } from "@/api/types";
 
+import { colors } from "@/lib/colors";
 import { formatCount, formatRelativeTime, truncateText } from "@/lib/format";
 
 import { QuotedPostCard } from "./QuotedPostCard";
 
 const MAX_TEXT_LINES = 3;
-const SELECTED_BG = "#1a1a2e";
-const X_BLUE = "#1DA1F2";
-const COLOR_SUCCESS = "#17BF63";
-const COLOR_WARNING = "#FFAD1F";
 
 interface PostCardProps {
   post: TweetData;
@@ -44,14 +41,14 @@ export function PostCard({
         paddingLeft: 1,
         paddingRight: 1,
         paddingTop: 1,
-        backgroundColor: isSelected ? SELECTED_BG : undefined,
+        backgroundColor: isSelected ? colors.selectedBg : undefined,
       }}
     >
       {/* Author line with selection indicator */}
       <box style={{ flexDirection: "row" }}>
-        <text fg={X_BLUE}>{isSelected ? "> " : "  "}</text>
-        <text fg={X_BLUE}>@{post.author.username}</text>
-        <text fg="#666666">
+        <text fg={colors.primary}>{isSelected ? "> " : "  "}</text>
+        <text fg={colors.primary}>@{post.author.username}</text>
+        <text fg={colors.dim}>
           {" "}
           · {post.author.name}
           {timeAgo ? ` · ${timeAgo}` : ""}
@@ -72,19 +69,19 @@ export function PostCard({
 
       {/* Stats line */}
       <box style={{ flexDirection: "row", marginTop: 1, paddingLeft: 2 }}>
-        <text fg="#888888">
+        <text fg={colors.muted}>
           {formatCount(post.replyCount)} replies {"  "}
           {formatCount(post.retweetCount)} reposts {"  "}
           {formatCount(post.likeCount)} likes
         </text>
         {isLiked ? (
-          <text fg="#E0245E">
+          <text fg={colors.error}>
             {"  "}
             {"\u2665"} liked
           </text>
         ) : null}
         {isBookmarked ? (
-          <text fg={X_BLUE}>
+          <text fg={colors.primary}>
             {"  "}
             {"\u2691"} saved
           </text>
@@ -107,10 +104,10 @@ export function PostCard({
                   : "GIF";
             const typeColor =
               item.type === "photo"
-                ? X_BLUE
+                ? colors.primary
                 : item.type === "video"
-                  ? COLOR_WARNING
-                  : COLOR_SUCCESS;
+                  ? colors.warning
+                  : colors.success;
             return (
               <text key={item.id} fg={typeColor}>
                 • {typeLabel}

--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -12,6 +12,7 @@ import type { TweetActionState } from "@/hooks/useActions";
 
 import { PostCard } from "@/components/PostCard";
 import { useListNavigation } from "@/hooks/useListNavigation";
+import { colors } from "@/lib/colors";
 
 interface PostListProps {
   posts: TweetData[];
@@ -187,7 +188,7 @@ export function PostList({
   if (posts.length === 0) {
     return (
       <box style={{ padding: 2 }}>
-        <text fg="#888888">No posts to display</text>
+        <text fg={colors.muted}>No posts to display</text>
       </box>
     );
   }
@@ -216,12 +217,12 @@ export function PostList({
       })}
       {loadingMore ? (
         <box style={{ padding: 1, paddingLeft: 2 }}>
-          <text fg="#888888">Loading more posts...</text>
+          <text fg={colors.muted}>Loading more posts...</text>
         </box>
       ) : null}
       {!hasMore && posts.length > 0 ? (
         <box style={{ padding: 1, paddingLeft: 2 }}>
-          <text fg="#666666">No more posts</text>
+          <text fg={colors.dim}>No more posts</text>
         </box>
       ) : null}
     </scrollbox>

--- a/src/components/QuotedPostCard.tsx
+++ b/src/components/QuotedPostCard.tsx
@@ -4,12 +4,12 @@
 
 import type { TweetData } from "@/api/types";
 
+import { colors } from "@/lib/colors";
 import { truncateText } from "@/lib/format";
 
 const MAX_TEXT_LINES = 2;
 const QUOTE_BORDER_COLOR = "#444444";
 const QUOTE_BG = "#0d0d14";
-const X_BLUE = "#1DA1F2";
 
 interface QuotedPostCardProps {
   post: TweetData;
@@ -33,8 +33,8 @@ export function QuotedPostCard({ post }: QuotedPostCardProps) {
       >
         {/* Quoted author line */}
         <box style={{ flexDirection: "row" }}>
-          <text fg={X_BLUE}>@{post.author.username}</text>
-          <text fg="#666666"> · {post.author.name}</text>
+          <text fg={colors.primary}>@{post.author.username}</text>
+          <text fg={colors.dim}> · {post.author.name}</text>
         </box>
 
         {/* Quoted text (truncated) */}

--- a/src/components/SessionExpiredModal.tsx
+++ b/src/components/SessionExpiredModal.tsx
@@ -1,5 +1,7 @@
 import { useKeyboard, useRenderer } from "@opentui/react";
 
+import { colors } from "@/lib/colors";
+
 export function SessionExpiredModal() {
   const renderer = useRenderer();
 
@@ -29,10 +31,10 @@ export function SessionExpiredModal() {
           alignItems: "center",
           gap: 1,
         }}
-        backgroundColor="#1a1a2e"
-        borderColor="#e63946"
+        backgroundColor={colors.selectedBg}
+        borderColor={colors.error}
       >
-        <text fg="#e63946">Session Expired</text>
+        <text fg={colors.error}>Session Expired</text>
         <text fg="#a8a8a8">Your tokens are no longer valid.</text>
         <box style={{ marginTop: 1, flexDirection: "row" }}>
           <text fg="#6b6b6b">Press </text>

--- a/src/components/ThreadView.prototype.tsx
+++ b/src/components/ThreadView.prototype.tsx
@@ -14,10 +14,9 @@ import { useState, useRef, useEffect, useMemo } from "react";
 
 import type { TweetData } from "@/api/types";
 
+import { colors } from "@/lib/colors";
 import { formatRelativeTime, truncateText } from "@/lib/format";
 
-const X_BLUE = "#1DA1F2";
-const FOCUSED_BG = "#1a1a2e";
 const SELECTED_BG = "#2a2a3e";
 
 // Tree drawing characters
@@ -153,7 +152,7 @@ function CompactPostCard({
       style={{
         flexDirection: "column",
         backgroundColor: isFocused
-          ? FOCUSED_BG
+          ? colors.selectedBg
           : isSelected
             ? SELECTED_BG
             : undefined,
@@ -163,12 +162,12 @@ function CompactPostCard({
       }}
     >
       <box style={{ flexDirection: "row" }}>
-        <text fg="#666666">{prefix}</text>
-        <text fg={isSelected ? X_BLUE : "#888888"}>
+        <text fg={colors.dim}>{prefix}</text>
+        <text fg={isSelected ? colors.primary : colors.muted}>
           {isSelected ? ">" : " "}
         </text>
-        <text fg={X_BLUE}>@{tweet.author.username}</text>
-        <text fg="#666666"> · {timeAgo}</text>
+        <text fg={colors.primary}>@{tweet.author.username}</text>
+        <text fg={colors.dim}> · {timeAgo}</text>
       </box>
       <box style={{ paddingLeft: prefix.length + 2 }}>
         <text fg={isFocused ? "#ffffff" : "#cccccc"}>{truncatedText}</text>
@@ -176,7 +175,7 @@ function CompactPostCard({
       {/* Stats line for focused tweet */}
       {isFocused && (
         <box style={{ paddingLeft: prefix.length + 2, marginTop: 1 }}>
-          <text fg="#888888">
+          <text fg={colors.muted}>
             {tweet.replyCount ?? 0} replies · {tweet.retweetCount ?? 0} reposts
             · {tweet.likeCount ?? 0} likes
           </text>
@@ -203,7 +202,7 @@ function AncestorChain({ ancestors }: { ancestors: TweetData[] }) {
       }}
     >
       <box style={{ marginBottom: 1 }}>
-        <text fg="#666666">Thread context:</text>
+        <text fg={colors.dim}>Thread context:</text>
       </box>
       {ancestors.map((tweet, idx) => {
         const isLast = idx === ancestors.length - 1;
@@ -214,12 +213,12 @@ function AncestorChain({ ancestors }: { ancestors: TweetData[] }) {
           <box key={tweet.id} style={{ flexDirection: "column" }}>
             <box style={{ flexDirection: "row" }}>
               <text fg="#555555">{prefix}</text>
-              <text fg={X_BLUE}>@{tweet.author.username}</text>
-              <text fg="#666666"> · {formatRelativeTime(tweet.createdAt)}</text>
+              <text fg={colors.primary}>@{tweet.author.username}</text>
+              <text fg={colors.dim}> · {formatRelativeTime(tweet.createdAt)}</text>
             </box>
             <box style={{ flexDirection: "row" }}>
               <text fg="#555555">{verticalLine} </text>
-              <text fg="#888888">{truncateText(tweet.text, 2)}</text>
+              <text fg={colors.muted}>{truncateText(tweet.text, 2)}</text>
             </box>
           </box>
         );
@@ -443,10 +442,10 @@ export function ThreadViewPrototype({
         flexDirection: "row",
       }}
     >
-      <text fg="#888888">Thread View</text>
-      <text fg="#666666"> · </text>
-      <text fg={X_BLUE}>{flatNodes.length}</text>
-      <text fg="#666666"> tweets</text>
+      <text fg={colors.muted}>Thread View</text>
+      <text fg={colors.dim}> · </text>
+      <text fg={colors.primary}>{flatNodes.length}</text>
+      <text fg={colors.dim}> tweets</text>
     </box>
   );
 
@@ -462,11 +461,11 @@ export function ThreadViewPrototype({
       }}
     >
       <text fg="#ffffff">j/k</text>
-      <text fg="#666666"> nav </text>
+      <text fg={colors.dim}> nav </text>
       <text fg="#ffffff">Enter</text>
-      <text fg="#666666"> view </text>
+      <text fg={colors.dim}> view </text>
       <text fg="#ffffff">h/Esc</text>
-      <text fg="#666666"> back</text>
+      <text fg={colors.dim}> back</text>
     </box>
   );
 
@@ -485,21 +484,21 @@ export function ThreadViewPrototype({
         <box
           style={{
             borderStyle: "single",
-            borderColor: X_BLUE,
+            borderColor: colors.primary,
             marginBottom: 1,
             paddingLeft: 1,
             paddingRight: 1,
           }}
         >
           <box style={{ flexDirection: "row" }}>
-            <text fg={X_BLUE}>@{focusedTweet.author.username}</text>
+            <text fg={colors.primary}>@{focusedTweet.author.username}</text>
             <text fg="#ffffff"> · {focusedTweet.author.name}</text>
           </box>
           <box style={{ marginTop: 1 }}>
             <text fg="#ffffff">{focusedTweet.text}</text>
           </box>
           <box style={{ marginTop: 1 }}>
-            <text fg="#888888">
+            <text fg={colors.muted}>
               {focusedTweet.replyCount ?? 0} replies ·{" "}
               {focusedTweet.retweetCount ?? 0} reposts ·{" "}
               {focusedTweet.likeCount ?? 0} likes
@@ -512,7 +511,7 @@ export function ThreadViewPrototype({
           <box style={{ marginTop: 1 }}>
             <box style={{ paddingLeft: 1, marginBottom: 1 }}>
               <text fg="#ffffff">Replies</text>
-              <text fg="#666666"> ({flatNodes.length})</text>
+              <text fg={colors.dim}> ({flatNodes.length})</text>
             </box>
             {treeState.children.map((child, idx) => (
               <TreeNode
@@ -530,7 +529,7 @@ export function ThreadViewPrototype({
         {/* No replies message */}
         {(!treeState || treeState.children.length === 0) && (
           <box style={{ paddingLeft: 1, marginTop: 1 }}>
-            <text fg="#666666">No replies yet</text>
+            <text fg={colors.dim}>No replies yet</text>
           </box>
         )}
       </scrollbox>

--- a/src/lib/colors.ts
+++ b/src/lib/colors.ts
@@ -1,0 +1,29 @@
+/**
+ * Centralized color constants for the xfeed application.
+ * Use these instead of magic color strings throughout the codebase.
+ */
+
+export const colors = {
+	/** X brand blue - used for primary elements, selection, links */
+	primary: "#1DA1F2",
+
+	/** Success green - used for likes, retweets, success states */
+	success: "#17BF63",
+
+	/** Warning orange - used for warning indicators */
+	warning: "#FFAD1F",
+
+	/** Error/Like red - used for errors and like icons */
+	error: "#E0245E",
+
+	/** Selection highlight background */
+	selectedBg: "#1a1a2e",
+
+	/** Muted/secondary text color */
+	muted: "#888888",
+
+	/** Dim text color - less prominent than muted */
+	dim: "#666666",
+} as const;
+
+export type ColorKey = keyof typeof colors;

--- a/src/screens/BookmarksScreen.tsx
+++ b/src/screens/BookmarksScreen.tsx
@@ -13,6 +13,7 @@ import type { TweetActionState } from "@/hooks/useActions";
 import { ErrorBanner } from "@/components/ErrorBanner";
 import { PostList } from "@/components/PostList";
 import { useBookmarks } from "@/hooks/useBookmarks";
+import { colors } from "@/lib/colors";
 
 interface BookmarksScreenProps {
   client: XClient;
@@ -46,7 +47,7 @@ function ScreenHeader() {
         flexDirection: "row",
       }}
     >
-      <text fg="#1DA1F2">
+      <text fg={colors.primary}>
         <b>All Bookmarks</b>
       </text>
     </box>
@@ -109,7 +110,7 @@ export function BookmarksScreen({
       <box style={{ flexDirection: "column", height: "100%" }}>
         <ScreenHeader />
         <box style={{ padding: 2, flexGrow: 1 }}>
-          <text fg="#888888">Loading bookmarks...</text>
+          <text fg={colors.muted}>Loading bookmarks...</text>
         </box>
       </box>
     );
@@ -141,7 +142,7 @@ export function BookmarksScreen({
         <ScreenHeader />
         <box style={{ padding: 2, flexGrow: 1 }}>
           <text fg="#ff6666">Error: {error}</text>
-          <text fg="#888888"> Press r to retry.</text>
+          <text fg={colors.muted}> Press r to retry.</text>
         </box>
       </box>
     );
@@ -152,7 +153,7 @@ export function BookmarksScreen({
       <box style={{ flexDirection: "column", height: "100%" }}>
         <ScreenHeader />
         <box style={{ padding: 2, flexGrow: 1 }}>
-          <text fg="#888888">No bookmarks yet. Press r to refresh.</text>
+          <text fg={colors.muted}>No bookmarks yet. Press r to refresh.</text>
         </box>
       </box>
     );
@@ -163,7 +164,7 @@ export function BookmarksScreen({
       <ScreenHeader />
       {actionMessage ? (
         <box style={{ paddingLeft: 1 }}>
-          <text fg={actionMessage.startsWith("Error:") ? "#E0245E" : "#17BF63"}>
+          <text fg={actionMessage.startsWith("Error:") ? colors.error : colors.success}>
             {actionMessage}
           </text>
         </box>

--- a/src/screens/NotificationsScreen.tsx
+++ b/src/screens/NotificationsScreen.tsx
@@ -12,6 +12,7 @@ import type { NotificationData } from "@/api/types";
 import { ErrorBanner } from "@/components/ErrorBanner";
 import { NotificationList } from "@/components/NotificationList";
 import { useNotifications } from "@/hooks/useNotifications";
+import { colors } from "@/lib/colors";
 
 interface NotificationsScreenProps {
   client: XClient;
@@ -34,10 +35,10 @@ function ScreenHeader({ unreadCount }: { unreadCount: number }) {
         flexDirection: "row",
       }}
     >
-      <text fg="#1DA1F2">
+      <text fg={colors.primary}>
         <b>Notifications</b>
       </text>
-      {unreadCount > 0 && <text fg="#E0245E"> ({unreadCount} new)</text>}
+      {unreadCount > 0 && <text fg={colors.error}> ({unreadCount} new)</text>}
     </box>
   );
 }
@@ -100,7 +101,7 @@ export function NotificationsScreen({
       <box style={{ flexDirection: "column", height: "100%" }}>
         <ScreenHeader unreadCount={0} />
         <box style={{ padding: 2, flexGrow: 1 }}>
-          <text fg="#888888">Loading notifications...</text>
+          <text fg={colors.muted}>Loading notifications...</text>
         </box>
       </box>
     );
@@ -132,7 +133,7 @@ export function NotificationsScreen({
         <ScreenHeader unreadCount={0} />
         <box style={{ padding: 2, flexGrow: 1 }}>
           <text fg="#ff6666">Error: {error}</text>
-          <text fg="#888888"> Press r to retry.</text>
+          <text fg={colors.muted}> Press r to retry.</text>
         </box>
       </box>
     );
@@ -143,7 +144,7 @@ export function NotificationsScreen({
       <box style={{ flexDirection: "column", height: "100%" }}>
         <ScreenHeader unreadCount={0} />
         <box style={{ padding: 2, flexGrow: 1 }}>
-          <text fg="#888888">No notifications yet. Press r to refresh.</text>
+          <text fg={colors.muted}>No notifications yet. Press r to refresh.</text>
         </box>
       </box>
     );
@@ -154,7 +155,7 @@ export function NotificationsScreen({
       <ScreenHeader unreadCount={unreadCount} />
       {actionMessage ? (
         <box style={{ paddingLeft: 1 }}>
-          <text fg={actionMessage.startsWith("Error:") ? "#E0245E" : "#17BF63"}>
+          <text fg={actionMessage.startsWith("Error:") ? colors.error : colors.success}>
             {actionMessage}
           </text>
         </box>

--- a/src/screens/PostDetailScreen.tsx
+++ b/src/screens/PostDetailScreen.tsx
@@ -16,6 +16,7 @@ import { QuotedPostCard } from "@/components/QuotedPostCard";
 import { useListNavigation } from "@/hooks/useListNavigation";
 import { usePostDetail } from "@/hooks/usePostDetail";
 import { formatCount, truncateText } from "@/lib/format";
+import { colors } from "@/lib/colors";
 import {
   previewMedia,
   downloadMedia,
@@ -23,10 +24,6 @@ import {
   fetchLinkMetadata,
   type LinkMetadata,
 } from "@/lib/media";
-
-const X_BLUE = "#1DA1F2";
-const COLOR_SUCCESS = "#17BF63";
-const COLOR_WARNING = "#FFAD1F";
 
 /**
  * Generate element ID for reply cards (for scroll targeting)
@@ -574,11 +571,11 @@ export function PostDetailScreen({
         flexDirection: "row",
       }}
     >
-      <text fg="#888888">
+      <text fg={colors.muted}>
         {repliesMode || mentionsMode ? "<- Back (Esc) | " : "<- Back (Esc)"}
       </text>
-      {repliesMode && <text fg={X_BLUE}>Navigating replies</text>}
-      {mentionsMode && <text fg={X_BLUE}>Navigating mentions</text>}
+      {repliesMode && <text fg={colors.primary}>Navigating replies</text>}
+      {mentionsMode && <text fg={colors.primary}>Navigating mentions</text>}
     </box>
   );
 
@@ -595,13 +592,13 @@ export function PostDetailScreen({
         }}
       >
         {loadingParent ? (
-          <text fg="#666666">Loading parent tweet...</text>
+          <text fg={colors.dim}>Loading parent tweet...</text>
         ) : parentTweet ? (
           <box style={{ flexDirection: "column" }}>
             <box style={{ flexDirection: "row" }}>
-              <text fg="#666666">Replying to </text>
-              <text fg={X_BLUE}>@{parentTweet.author.username}</text>
-              <text fg="#888888"> · {parentTweet.author.name}</text>
+              <text fg={colors.dim}>Replying to </text>
+              <text fg={colors.primary}>@{parentTweet.author.username}</text>
+              <text fg={colors.muted}> · {parentTweet.author.name}</text>
             </box>
             <box style={{ marginTop: 1 }}>
               <text fg="#aaaaaa">{truncateText(parentTweet.text, 3)}</text>
@@ -615,12 +612,12 @@ export function PostDetailScreen({
   const authorContent = (
     <box style={{ flexDirection: "column", paddingLeft: 1, paddingRight: 1 }}>
       <box style={{ flexDirection: "row" }}>
-        <text fg={X_BLUE}>@{tweet.author.username}</text>
+        <text fg={colors.primary}>@{tweet.author.username}</text>
         <text fg="#ffffff"> · {tweet.author.name}</text>
       </box>
       {fullTimestamp && (
         <box style={{ marginTop: 0 }}>
-          <text fg="#666666">{fullTimestamp}</text>
+          <text fg={colors.dim}>{fullTimestamp}</text>
         </box>
       )}
     </box>
@@ -630,7 +627,7 @@ export function PostDetailScreen({
   const postContent = (
     <box style={{ marginTop: 1, paddingLeft: 1, paddingRight: 1 }}>
       {hasMentions ? (
-        renderTextWithMentions(displayText, X_BLUE, "#ffffff")
+        renderTextWithMentions(displayText, colors.primary, "#ffffff")
       ) : (
         <text fg="#ffffff">{displayText}</text>
       )}
@@ -640,8 +637,8 @@ export function PostDetailScreen({
   // Truncation indicator
   const truncationIndicator = showTruncated ? (
     <box style={{ paddingLeft: 1, marginTop: 1 }}>
-      <text fg="#666666">... </text>
-      <text fg={X_BLUE}>[e] Expand</text>
+      <text fg={colors.dim}>... </text>
+      <text fg={colors.primary}>[e] Expand</text>
     </box>
   ) : null;
 
@@ -656,7 +653,7 @@ export function PostDetailScreen({
   const statsContent = (
     <box style={{ marginTop: 1, paddingLeft: 1, paddingRight: 1 }}>
       <box style={{ flexDirection: "row" }}>
-        <text fg="#888888">
+        <text fg={colors.muted}>
           {formatCount(tweet.replyCount)} replies {"  "}
           {formatCount(tweet.retweetCount)} reposts {"  "}
           {formatCount(tweet.likeCount)} likes
@@ -680,10 +677,10 @@ export function PostDetailScreen({
                 : "GIF";
           const typeColor =
             item.type === "photo"
-              ? X_BLUE
+              ? colors.primary
               : item.type === "video"
-                ? COLOR_WARNING
-                : COLOR_SUCCESS;
+                ? colors.warning
+                : colors.success;
           const isSelected = idx === mediaIndex;
           return (
             <text key={item.id} fg={typeColor}>
@@ -694,11 +691,11 @@ export function PostDetailScreen({
             </text>
           );
         })}
-        <text fg="#666666">(</text>
-        <text fg={X_BLUE}>i</text>
-        <text fg="#666666"> view, </text>
-        <text fg={X_BLUE}>d</text>
-        <text fg="#666666"> download)</text>
+        <text fg={colors.dim}>(</text>
+        <text fg={colors.primary}>i</text>
+        <text fg={colors.dim}> view, </text>
+        <text fg={colors.primary}>d</text>
+        <text fg={colors.dim}> download)</text>
       </box>
     </box>
   ) : null;
@@ -708,15 +705,15 @@ export function PostDetailScreen({
     <box style={{ marginTop: 1, paddingLeft: 1, paddingRight: 1 }}>
       <box style={{ flexDirection: "column" }}>
         <box style={{ flexDirection: "row" }}>
-          <text fg="#666666">Links: </text>
+          <text fg={colors.dim}>Links: </text>
           {linkCount > 1 && (
             <>
-              <text fg={X_BLUE}>,/.</text>
-              <text fg="#666666"> navigate </text>
+              <text fg={colors.primary}>,/.</text>
+              <text fg={colors.dim}> navigate </text>
             </>
           )}
-          <text fg={X_BLUE}>o</text>
-          <text fg="#666666"> open</text>
+          <text fg={colors.primary}>o</text>
+          <text fg={colors.dim}> open</text>
         </box>
         {tweet.urls?.map((link, idx) => {
           const isSelected = idx === linkIndex;
@@ -727,18 +724,18 @@ export function PostDetailScreen({
               style={{ flexDirection: "column", marginTop: idx === 0 ? 1 : 0 }}
             >
               <box style={{ flexDirection: "row" }}>
-                <text fg={isSelected ? X_BLUE : "#888888"}>
+                <text fg={isSelected ? colors.primary : colors.muted}>
                   {isSelected ? ">" : " "} {link.displayUrl}
                 </text>
               </box>
               {showMetadata && linkMetadata.title && (
                 <box style={{ paddingLeft: 2 }}>
-                  <text fg="#666666"> "{linkMetadata.title}"</text>
+                  <text fg={colors.dim}> "{linkMetadata.title}"</text>
                 </box>
               )}
               {isSelected && isLoadingMetadata && (
                 <box style={{ paddingLeft: 2 }}>
-                  <text fg="#666666"> Loading...</text>
+                  <text fg={colors.dim}> Loading...</text>
                 </box>
               )}
             </box>
@@ -756,24 +753,24 @@ export function PostDetailScreen({
         {mentionCount === 1 ? (
           // Single mention - show directly with profile shortcut
           <box style={{ flexDirection: "row" }}>
-            <text fg="#666666">Mentions: </text>
-            <text fg={X_BLUE}>@{firstMention?.username}</text>
+            <text fg={colors.dim}>Mentions: </text>
+            <text fg={colors.primary}>@{firstMention?.username}</text>
             {firstMention?.name && (
-              <text fg="#666666"> · {firstMention.name}</text>
+              <text fg={colors.dim}> · {firstMention.name}</text>
             )}
-            <text fg="#666666"> (</text>
-            <text fg={X_BLUE}>m</text>
-            <text fg="#666666"> profile)</text>
+            <text fg={colors.dim}> (</text>
+            <text fg={colors.primary}>m</text>
+            <text fg={colors.dim}> profile)</text>
           </box>
         ) : mentionsMode ? (
           // Multiple mentions - navigation mode active
           <>
             <box style={{ flexDirection: "row" }}>
-              <text fg="#666666">Mentions ({mentionCount}): </text>
-              <text fg={X_BLUE}>j/k</text>
-              <text fg="#666666"> navigate </text>
-              <text fg={X_BLUE}>Enter</text>
-              <text fg="#666666"> profile</text>
+              <text fg={colors.dim}>Mentions ({mentionCount}): </text>
+              <text fg={colors.primary}>j/k</text>
+              <text fg={colors.dim}> navigate </text>
+              <text fg={colors.primary}>Enter</text>
+              <text fg={colors.dim}> profile</text>
             </box>
             {tweet.mentions?.map((mention, idx) => {
               const isSelected = idx === mentionIndex;
@@ -782,10 +779,10 @@ export function PostDetailScreen({
                   key={mention.username}
                   style={{ flexDirection: "row", marginTop: idx === 0 ? 1 : 0 }}
                 >
-                  <text fg={isSelected ? X_BLUE : "#888888"}>
+                  <text fg={isSelected ? colors.primary : colors.muted}>
                     {isSelected ? ">" : " "} @{mention.username}
                   </text>
-                  {mention.name && <text fg="#666666"> · {mention.name}</text>}
+                  {mention.name && <text fg={colors.dim}> · {mention.name}</text>}
                 </box>
               );
             })}
@@ -793,11 +790,11 @@ export function PostDetailScreen({
         ) : (
           // Multiple mentions - collapsed view
           <box style={{ flexDirection: "row" }}>
-            <text fg="#666666">Mentions: </text>
-            <text fg={X_BLUE}>@{firstMention?.username}</text>
-            <text fg="#666666"> +{mentionCount - 1} more (</text>
-            <text fg={X_BLUE}>m</text>
-            <text fg="#666666"> to navigate)</text>
+            <text fg={colors.dim}>Mentions: </text>
+            <text fg={colors.primary}>@{firstMention?.username}</text>
+            <text fg={colors.dim}> +{mentionCount - 1} more (</text>
+            <text fg={colors.primary}>m</text>
+            <text fg={colors.dim}> to navigate)</text>
           </box>
         )}
       </box>
@@ -812,11 +809,11 @@ export function PostDetailScreen({
           <text fg="#ffffff">Replies</text>
           {hasReplies && (
             <>
-              <text fg="#666666"> ({replies.length}) </text>
+              <text fg={colors.dim}> ({replies.length}) </text>
               {!repliesMode && (
                 <>
-                  <text fg={X_BLUE}>r</text>
-                  <text fg="#666666"> to navigate</text>
+                  <text fg={colors.primary}>r</text>
+                  <text fg={colors.dim}> to navigate</text>
                 </>
               )}
             </>
@@ -825,7 +822,7 @@ export function PostDetailScreen({
 
         {loadingReplies ? (
           <box>
-            <text fg="#666666">Loading replies...</text>
+            <text fg={colors.dim}>Loading replies...</text>
           </box>
         ) : hasReplies ? (
           <box style={{ flexDirection: "column" }}>
@@ -845,7 +842,7 @@ export function PostDetailScreen({
           </box>
         ) : (
           <box>
-            <text fg="#666666">No replies yet</text>
+            <text fg={colors.dim}>No replies yet</text>
           </box>
         )}
       </box>
@@ -857,7 +854,7 @@ export function PostDetailScreen({
   const isError = displayMessage?.startsWith("Error:");
   const statusContent = displayMessage ? (
     <box style={{ marginTop: 1, paddingLeft: 1, paddingRight: 1 }}>
-      <text fg={isError ? "#E0245E" : "#00aa00"}>{displayMessage}</text>
+      <text fg={isError ? colors.error : colors.success}>{displayMessage}</text>
     </box>
   ) : null;
 
@@ -874,46 +871,46 @@ export function PostDetailScreen({
       }}
     >
       <text fg="#ffffff">h/Esc</text>
-      <text fg="#666666"> back </text>
+      <text fg={colors.dim}> back </text>
       {showTruncated ? (
         <>
           <text fg="#ffffff">e</text>
-          <text fg="#666666"> expand </text>
+          <text fg={colors.dim}> expand </text>
         </>
       ) : isExpanded ? (
         <>
           <text fg="#ffffff">e</text>
-          <text fg="#666666"> collapse </text>
+          <text fg={colors.dim}> collapse </text>
         </>
       ) : null}
       <text fg="#ffffff">x</text>
-      <text fg="#666666"> x.com </text>
+      <text fg={colors.dim}> x.com </text>
       <text fg="#ffffff">b</text>
-      <text fg={isBookmarked ? X_BLUE : "#666666"}>
+      <text fg={isBookmarked ? colors.primary : colors.dim}>
         {isBookmarked ? " ⚑" : " bookmark"}{" "}
       </text>
       {isBookmarked && !hasMentions && (
         <>
           <text fg="#ffffff">m</text>
-          <text fg="#666666"> folder </text>
+          <text fg={colors.dim}> folder </text>
         </>
       )}
       <text fg="#ffffff">l</text>
-      <text fg={isLiked ? "#E0245E" : "#666666"}>
+      <text fg={isLiked ? colors.error : colors.dim}>
         {isLiked ? " ♥" : " like"}{" "}
       </text>
       <text fg="#ffffff">p</text>
-      <text fg="#666666"> profile</text>
+      <text fg={colors.dim}> profile</text>
       {hasMedia && (
         <>
           <text fg="#ffffff"> i</text>
-          <text fg="#666666"> preview </text>
+          <text fg={colors.dim}> preview </text>
           <text fg="#ffffff">d</text>
-          <text fg="#666666"> download</text>
+          <text fg={colors.dim}> download</text>
           {mediaCount > 1 && (
             <>
               <text fg="#ffffff"> [/]</text>
-              <text fg="#666666"> media</text>
+              <text fg={colors.dim}> media</text>
             </>
           )}
         </>
@@ -921,7 +918,7 @@ export function PostDetailScreen({
       {hasMentions && !mentionsMode && (
         <>
           <text fg="#ffffff"> m</text>
-          <text fg="#666666">
+          <text fg={colors.dim}>
             {mentionCount === 1 ? " @profile" : " mentions"}
           </text>
         </>
@@ -929,23 +926,23 @@ export function PostDetailScreen({
       {hasReplies && !repliesMode && (
         <>
           <text fg="#ffffff"> r</text>
-          <text fg="#666666"> replies</text>
+          <text fg={colors.dim}> replies</text>
         </>
       )}
       {hasLinks && (
         <>
           <text fg="#ffffff"> o</text>
-          <text fg="#666666"> link</text>
+          <text fg={colors.dim}> link</text>
           {linkCount > 1 && (
             <>
               <text fg="#ffffff"> ,/.</text>
-              <text fg="#666666"> nav</text>
+              <text fg={colors.dim}> nav</text>
             </>
           )}
         </>
       )}
       <text fg="#ffffff"> t</text>
-      <text fg="#666666"> thread</text>
+      <text fg={colors.dim}> thread</text>
     </box>
   );
 

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -12,10 +12,9 @@ import type { TweetActionState } from "@/hooks/useActions";
 
 import { PostList } from "@/components/PostList";
 import { useUserProfile } from "@/hooks/useUserProfile";
+import { colors } from "@/lib/colors";
 import { formatCount } from "@/lib/format";
 import { openInBrowser, previewImageUrl } from "@/lib/media";
-
-const X_BLUE = "#1DA1F2";
 
 /**
  * Format X's created_at date to "Joined Month Year"
@@ -142,12 +141,12 @@ export function ProfileScreen({
         flexDirection: "row",
       }}
     >
-      <text fg="#666666">{"<- "}</text>
+      <text fg={colors.dim}>{"<- "}</text>
       <text fg="#ffffff">
         <b>{user.name}</b>
       </text>
-      {user.isBlueVerified && <text fg={X_BLUE}> {"\u2713"}</text>}
-      <text fg="#888888"> @{user.username}</text>
+      {user.isBlueVerified && <text fg={colors.primary}> {"\u2713"}</text>}
+      <text fg={colors.muted}> @{user.username}</text>
     </box>
   );
 
@@ -159,12 +158,12 @@ export function ProfileScreen({
     <box style={{ flexShrink: 0, flexDirection: "column" }}>
       {/* Back hint + Name + Handle on same line */}
       <box style={{ paddingLeft: 1, paddingRight: 1, flexDirection: "row" }}>
-        <text fg="#666666">{"<- "}</text>
+        <text fg={colors.dim}>{"<- "}</text>
         <text fg="#ffffff">
           <b>{user.name}</b>
         </text>
-        {user.isBlueVerified && <text fg={X_BLUE}> {"\u2713"}</text>}
-        <text fg="#888888"> @{user.username}</text>
+        {user.isBlueVerified && <text fg={colors.primary}> {"\u2713"}</text>}
+        <text fg={colors.muted}> @{user.username}</text>
       </box>
 
       {/* Bio */}
@@ -179,25 +178,25 @@ export function ProfileScreen({
         <box style={{ paddingLeft: 1, paddingRight: 1, flexDirection: "row" }}>
           {user.location && (
             <>
-              <text fg="#888888">{"\u{1F4CD}"} </text>
+              <text fg={colors.muted}>{"\u{1F4CD}"} </text>
               <text fg="#aaaaaa">{user.location}</text>
             </>
           )}
           {user.location && websiteDomain && (
-            <text fg="#666666"> {"\u00B7"} </text>
+            <text fg={colors.dim}> {"\u00B7"} </text>
           )}
           {websiteDomain && (
             <>
-              <text fg="#888888">{"\u{1F517}"} </text>
-              <text fg={X_BLUE}>{websiteDomain}</text>
+              <text fg={colors.muted}>{"\u{1F517}"} </text>
+              <text fg={colors.primary}>{websiteDomain}</text>
             </>
           )}
           {(user.location || websiteDomain) && joinDate && (
-            <text fg="#666666"> {"\u00B7"} </text>
+            <text fg={colors.dim}> {"\u00B7"} </text>
           )}
           {joinDate && (
             <>
-              <text fg="#888888">{"\u{1F4C5}"} </text>
+              <text fg={colors.muted}>{"\u{1F4C5}"} </text>
               <text fg="#aaaaaa">{joinDate}</text>
             </>
           )}
@@ -207,10 +206,10 @@ export function ProfileScreen({
       {/* Stats */}
       <box style={{ paddingLeft: 1, paddingRight: 1, flexDirection: "row" }}>
         <text fg="#ffffff">{formatCount(user.followersCount)}</text>
-        <text fg="#888888"> Followers </text>
-        <text fg="#666666">{"\u00B7"} </text>
+        <text fg={colors.muted}> Followers </text>
+        <text fg={colors.dim}>{"\u00B7"} </text>
         <text fg="#ffffff">{formatCount(user.followingCount)}</text>
-        <text fg="#888888"> Following</text>
+        <text fg={colors.muted}> Following</text>
       </box>
     </box>
   );
@@ -233,35 +232,35 @@ export function ProfileScreen({
       }}
     >
       <text fg="#ffffff">h/Esc</text>
-      <text fg="#666666"> back </text>
+      <text fg={colors.dim}> back </text>
       <text fg="#ffffff">j/k</text>
-      <text fg="#666666"> nav </text>
+      <text fg={colors.dim}> nav </text>
       <text fg="#ffffff">l</text>
-      <text fg="#666666"> like </text>
+      <text fg={colors.dim}> like </text>
       <text fg="#ffffff">b</text>
-      <text fg="#666666"> bkmk </text>
+      <text fg={colors.dim}> bkmk </text>
       {user?.profileImageUrl && (
         <>
           <text fg="#ffffff">a</text>
-          <text fg="#666666"> avatar </text>
+          <text fg={colors.dim}> avatar </text>
         </>
       )}
       {user?.bannerImageUrl && (
         <>
           <text fg="#ffffff">v</text>
-          <text fg="#666666"> banner </text>
+          <text fg={colors.dim}> banner </text>
         </>
       )}
       {user?.websiteUrl && (
         <>
           <text fg="#ffffff">w</text>
-          <text fg="#666666"> web </text>
+          <text fg={colors.dim}> web </text>
         </>
       )}
       <text fg="#ffffff">x</text>
-      <text fg="#666666"> x.com </text>
+      <text fg={colors.dim}> x.com </text>
       <text fg="#ffffff">r</text>
-      <text fg="#666666"> refresh</text>
+      <text fg={colors.dim}> refresh</text>
     </box>
   );
 
@@ -270,8 +269,8 @@ export function ProfileScreen({
     return (
       <box style={{ flexDirection: "column", height: "100%" }}>
         <box style={{ padding: 1, flexDirection: "row" }}>
-          <text fg="#666666">{"<- "}</text>
-          <text fg="#888888">Loading profile...</text>
+          <text fg={colors.dim}>{"<- "}</text>
+          <text fg={colors.muted}>Loading profile...</text>
         </box>
       </box>
     );
@@ -282,7 +281,7 @@ export function ProfileScreen({
     return (
       <box style={{ flexDirection: "column", height: "100%" }}>
         <box style={{ padding: 1, flexDirection: "row" }}>
-          <text fg="#666666">{"<- "}</text>
+          <text fg={colors.dim}>{"<- "}</text>
           <text fg="#ff6666">Error: {error}</text>
         </box>
       </box>
@@ -294,8 +293,8 @@ export function ProfileScreen({
     return (
       <box style={{ flexDirection: "column", height: "100%" }}>
         <box style={{ padding: 1, flexDirection: "row" }}>
-          <text fg="#666666">{"<- "}</text>
-          <text fg="#888888">User not found</text>
+          <text fg={colors.dim}>{"<- "}</text>
+          <text fg={colors.muted}>User not found</text>
         </box>
       </box>
     );
@@ -307,7 +306,7 @@ export function ProfileScreen({
       {separator}
       {actionMessage ? (
         <box style={{ paddingLeft: 1 }}>
-          <text fg={actionMessage.startsWith("Error:") ? "#E0245E" : "#17BF63"}>
+          <text fg={actionMessage.startsWith("Error:") ? colors.error : colors.success}>
             {actionMessage}
           </text>
         </box>
@@ -325,7 +324,7 @@ export function ProfileScreen({
         />
       ) : (
         <box style={{ padding: 1, flexGrow: 1 }}>
-          <text fg="#888888">No tweets to display</text>
+          <text fg={colors.muted}>No tweets to display</text>
         </box>
       )}
       {footerContent}

--- a/src/screens/SplashScreen.tsx
+++ b/src/screens/SplashScreen.tsx
@@ -5,6 +5,8 @@
 
 import { useEffect, useState } from "react";
 
+import { colors } from "@/lib/colors";
+
 // ASCII art logo
 const LOGO = [
   "          ██╗  ██╗███████╗███████╗███████╗██████╗ ",
@@ -17,9 +19,6 @@ const LOGO = [
 
 const SPINNER_FRAMES = ["◢", "◣", "◤", "◥"];
 const SPINNER_INTERVAL_MS = 100;
-
-const PRIMARY = "#ffffff"; // White
-const DIM = "#666666"; // Gray
 
 export function SplashScreen() {
   const [spinnerIndex, setSpinnerIndex] = useState(0);
@@ -42,13 +41,13 @@ export function SplashScreen() {
       }}
     >
       {/* Top border */}
-      <text fg={DIM}>{"─".repeat(52)}</text>
+      <text fg={colors.dim}>{"─".repeat(52)}</text>
 
       <box style={{ marginTop: 1 }} />
 
       {/* Logo */}
       {LOGO.map((line, i) => (
-        <text key={i} fg={PRIMARY}>
+        <text key={i} fg="#ffffff">
           {line}
         </text>
       ))}
@@ -56,17 +55,17 @@ export function SplashScreen() {
       <box style={{ marginTop: 1 }} />
 
       {/* Tagline */}
-      <text fg={DIM}>{"[terminal client for X, everything app]"}</text>
+      <text fg={colors.dim}>{"[terminal client for X, everything app]"}</text>
 
       <box style={{ marginTop: 1 }} />
 
       {/* Bottom border */}
-      <text fg={DIM}>{"─".repeat(52)}</text>
+      <text fg={colors.dim}>{"─".repeat(52)}</text>
 
       {/* Spinner and loading text */}
       <box style={{ marginTop: 2, flexDirection: "row" }}>
-        <text fg={PRIMARY}>{SPINNER_FRAMES[spinnerIndex]}</text>
-        <text fg={DIM}> initializing...</text>
+        <text fg="#ffffff">{SPINNER_FRAMES[spinnerIndex]}</text>
+        <text fg={colors.dim}> initializing...</text>
       </box>
     </box>
   );

--- a/src/screens/ThreadScreen.tsx
+++ b/src/screens/ThreadScreen.tsx
@@ -12,6 +12,7 @@ import type { TweetData } from "@/api/types";
 
 import { ThreadViewPrototype } from "@/components/ThreadView.prototype";
 import { useThread } from "@/hooks/useThread.prototype";
+import { colors } from "@/lib/colors";
 
 interface ThreadScreenProps {
   client: XClient;
@@ -40,7 +41,7 @@ export function ThreadScreen({
     return (
       <box style={{ flexDirection: "column", height: "100%" }}>
         <box style={{ paddingLeft: 1, paddingTop: 1 }}>
-          <text fg="#888888">
+          <text fg={colors.muted}>
             Loading thread...
             {loadingAncestors && " (ancestors)"}
             {loadingReplies && " (replies)"}
@@ -55,10 +56,10 @@ export function ThreadScreen({
     return (
       <box style={{ flexDirection: "column", height: "100%" }}>
         <box style={{ paddingLeft: 1, paddingTop: 1 }}>
-          <text fg="#E0245E">Error: {error}</text>
+          <text fg={colors.error}>Error: {error}</text>
         </box>
         <box style={{ paddingLeft: 1, paddingTop: 1 }}>
-          <text fg="#666666">Press h or Esc to go back</text>
+          <text fg={colors.dim}>Press h or Esc to go back</text>
         </box>
       </box>
     );

--- a/src/screens/TimelineScreen.tsx
+++ b/src/screens/TimelineScreen.tsx
@@ -13,6 +13,7 @@ import type { TweetActionState } from "@/hooks/useActions";
 import { ErrorBanner } from "@/components/ErrorBanner";
 import { PostList } from "@/components/PostList";
 import { useTimeline, type TimelineTab } from "@/hooks/useTimeline";
+import { colors } from "@/lib/colors";
 
 interface TimelineScreenProps {
   client: XClient;
@@ -50,11 +51,11 @@ function TabBar({ activeTab }: TabBarProps) {
         flexDirection: "row",
       }}
     >
-      <text fg={activeTab === "for_you" ? "#1DA1F2" : "#666666"}>
+      <text fg={activeTab === "for_you" ? colors.primary : colors.dim}>
         {activeTab === "for_you" ? <b>[1] For You</b> : " 1  For You"}
       </text>
-      <text fg="#666666"> | </text>
-      <text fg={activeTab === "following" ? "#1DA1F2" : "#666666"}>
+      <text fg={colors.dim}> | </text>
+      <text fg={activeTab === "following" ? colors.primary : colors.dim}>
         {activeTab === "following" ? <b>[2] Following</b> : " 2  Following"}
       </text>
     </box>
@@ -131,7 +132,7 @@ export function TimelineScreen({
       <box style={{ flexDirection: "column", height: "100%" }}>
         {focused && <TabBar activeTab={tab} />}
         <box style={{ padding: 2, flexGrow: 1 }}>
-          <text fg="#888888">Loading timeline...</text>
+          <text fg={colors.muted}>Loading timeline...</text>
         </box>
       </box>
     );
@@ -163,7 +164,7 @@ export function TimelineScreen({
         {focused && <TabBar activeTab={tab} />}
         <box style={{ padding: 2, flexGrow: 1 }}>
           <text fg="#ff6666">Error: {error}</text>
-          <text fg="#888888"> Press r to retry.</text>
+          <text fg={colors.muted}> Press r to retry.</text>
         </box>
       </box>
     );
@@ -174,7 +175,7 @@ export function TimelineScreen({
       <box style={{ flexDirection: "column", height: "100%" }}>
         {focused && <TabBar activeTab={tab} />}
         <box style={{ padding: 2, flexGrow: 1 }}>
-          <text fg="#888888">No posts to display. Press r to refresh.</text>
+          <text fg={colors.muted}>No posts to display. Press r to refresh.</text>
         </box>
       </box>
     );
@@ -185,7 +186,7 @@ export function TimelineScreen({
       {focused && <TabBar activeTab={tab} />}
       {actionMessage ? (
         <box style={{ paddingLeft: 1 }}>
-          <text fg={actionMessage.startsWith("Error:") ? "#E0245E" : "#17BF63"}>
+          <text fg={actionMessage.startsWith("Error:") ? colors.error : colors.success}>
             {actionMessage}
           </text>
         </box>


### PR DESCRIPTION
Create a centralized colors module to eliminate magic color strings
scattered across 19+ source files.

Colors centralized:
- primary (#1DA1F2): X blue - primary brand color
- success (#17BF63): Green for likes, success states
- warning (#FFAD1F): Orange for warnings
- error (#E0245E): Red for errors and like icons
- selectedBg (#1a1a2e): Selection highlight background
- muted (#888888): Secondary text color
- dim (#666666): Less prominent text color

Updated files:
- All component files in src/components/
- All screen files in src/screens/