### PR TITLE
refactor(hooks): Extract shared pagination logic into usePaginatedData hook

### DIFF
--- a/src/hooks/useBookmarks.ts
+++ b/src/hooks/useBookmarks.ts
@@ -3,10 +3,13 @@
  * with infinite scroll pagination and typed error handling with rate limit detection
  */
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useCallback } from "react";
 
 import type { XClient } from "@/api/client";
 import type { ApiError, TweetData } from "@/api/types";
+
+import { usePaginatedData } from "./usePaginatedData";
+import type { PaginatedFetchResult } from "./usePaginatedData";
 
 export interface UseBookmarksOptions {
   client: XClient;
@@ -38,122 +41,40 @@ export interface UseBookmarksResult {
 export function useBookmarks({
   client,
 }: UseBookmarksOptions): UseBookmarksResult {
-  const [posts, setPosts] = useState<TweetData[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [loadingMore, setLoadingMore] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [apiError, setApiError] = useState<ApiError | null>(null);
-  const [refreshCounter, setRefreshCounter] = useState(0);
-  const [retryCountdown, setRetryCountdown] = useState(0);
-  const [nextCursor, setNextCursor] = useState<string | undefined>();
-  const [hasMore, setHasMore] = useState(true);
-  const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  // Create fetch function that adapts client API to PaginatedFetchResult
+  const fetchFn = useCallback(
+    async (cursor?: string): Promise<PaginatedFetchResult<TweetData>> => {
+      const result = await client.getBookmarksV2(30, cursor);
 
-  // Track seen IDs to deduplicate posts across pages
-  const seenIds = useRef(new Set<string>());
-
-  // Clear countdown timer on unmount
-  useEffect(() => {
-    return () => {
-      if (countdownRef.current) {
-        clearInterval(countdownRef.current);
+      if (result.success) {
+        return {
+          success: true,
+          items: result.tweets,
+          nextCursor: result.nextCursor,
+        };
       }
-    };
-  }, []);
+      return { success: false, error: result.error };
+    },
+    [client]
+  );
 
-  const fetchBookmarks = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    setApiError(null);
-    // Reset pagination state for fresh fetch
-    seenIds.current.clear();
+  const getId = useCallback((tweet: TweetData) => tweet.id, []);
 
-    const result = await client.getBookmarksV2(30);
-
-    if (result.success) {
-      // Populate seen IDs with initial posts
-      for (const tweet of result.tweets) {
-        seenIds.current.add(tweet.id);
-      }
-      setPosts(result.tweets);
-      setNextCursor(result.nextCursor);
-      setHasMore(!!result.nextCursor && result.tweets.length > 0);
-      setRetryCountdown(0);
-      if (countdownRef.current) {
-        clearInterval(countdownRef.current);
-        countdownRef.current = null;
-      }
-    } else {
-      setError(result.error.message);
-      setApiError(result.error);
-      setHasMore(false);
-
-      // Start countdown for rate limits
-      if (result.error.type === "rate_limit" && result.error.retryAfter) {
-        setRetryCountdown(result.error.retryAfter);
-
-        // Clear any existing countdown
-        if (countdownRef.current) {
-          clearInterval(countdownRef.current);
-        }
-
-        // Start new countdown
-        countdownRef.current = setInterval(() => {
-          setRetryCountdown((prev) => {
-            if (prev <= 1) {
-              if (countdownRef.current) {
-                clearInterval(countdownRef.current);
-                countdownRef.current = null;
-              }
-              return 0;
-            }
-            return prev - 1;
-          });
-        }, 1000);
-      }
-    }
-
-    setLoading(false);
-  }, [client]);
-
-  // Fetch on mount and when refresh is triggered
-  useEffect(() => {
-    fetchBookmarks();
-  }, [fetchBookmarks, refreshCounter]);
-
-  const loadMore = useCallback(async () => {
-    if (!nextCursor || loadingMore || !hasMore) return;
-
-    setLoadingMore(true);
-
-    const result = await client.getBookmarksV2(30, nextCursor);
-
-    if (result.success) {
-      // Filter out duplicates using seenIds
-      const newPosts = result.tweets.filter((t) => !seenIds.current.has(t.id));
-      for (const tweet of newPosts) {
-        seenIds.current.add(tweet.id);
-      }
-
-      setPosts((prev) => [...prev, ...newPosts]);
-      setNextCursor(result.nextCursor);
-      setHasMore(!!result.nextCursor && result.tweets.length > 0);
-    } else {
-      // On error, don't clear existing posts, just stop pagination
-      setHasMore(false);
-    }
-
-    setLoadingMore(false);
-  }, [client, nextCursor, loadingMore, hasMore]);
-
-  const refresh = useCallback(() => {
-    // Don't allow refresh during rate limit countdown
-    if (retryCountdown > 0) return;
-    // Reset pagination state before refresh
-    setNextCursor(undefined);
-    setHasMore(true);
-    setRefreshCounter((prev) => prev + 1);
-  }, [retryCountdown]);
+  const {
+    data: posts,
+    loading,
+    loadingMore,
+    hasMore,
+    error,
+    apiError,
+    refresh,
+    loadMore,
+    retryBlocked,
+    retryCountdown,
+  } = usePaginatedData({
+    fetchFn,
+    getId,
+  });
 
   return {
     posts,
@@ -164,7 +85,7 @@ export function useBookmarks({
     apiError,
     refresh,
     loadMore,
-    retryBlocked: retryCountdown > 0,
+    retryBlocked,
     retryCountdown,
   };
 }

--- a/src/hooks/usePaginatedData.ts
+++ b/src/hooks/usePaginatedData.ts
@@ -1,0 +1,206 @@
+/**
+ * usePaginatedData - Generic hook for paginated data fetching
+ * Handles loading states, error handling, rate limit countdowns,
+ * deduplication, and infinite scroll pagination
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { ApiError } from "@/api/types";
+
+/**
+ * Result type for paginated fetch operations
+ */
+export type PaginatedFetchResult<T> =
+  | { success: true; items: T[]; nextCursor?: string }
+  | { success: false; error: ApiError };
+
+/**
+ * Options for configuring the usePaginatedData hook
+ */
+export interface PaginatedDataOptions<T> {
+  /** Function to fetch data, receives cursor for pagination */
+  fetchFn: (cursor?: string) => Promise<PaginatedFetchResult<T>>;
+  /** Extract unique ID from each item for deduplication */
+  getId: (item: T) => string;
+  /** Dependencies that trigger a full refetch when changed */
+  deps?: unknown[];
+}
+
+/**
+ * Result returned by the usePaginatedData hook
+ */
+export interface PaginatedDataResult<T> {
+  /** List of fetched items */
+  data: T[];
+  /** Whether initial data is loading */
+  loading: boolean;
+  /** Whether more data is being loaded (pagination) */
+  loadingMore: boolean;
+  /** Whether there are more items to load */
+  hasMore: boolean;
+  /** Error message if fetch failed (legacy string for backwards compat) */
+  error: string | null;
+  /** Typed error with rate limit info, auth status, etc. */
+  apiError: ApiError | null;
+  /** Refresh data (resets to first page) */
+  refresh: () => void;
+  /** Load more items (pagination) */
+  loadMore: () => void;
+  /** Whether retry is currently blocked (e.g., rate limit countdown) */
+  retryBlocked: boolean;
+  /** Seconds until retry is allowed (for rate limit countdown) */
+  retryCountdown: number;
+  /** Reset all data and state (useful for tab switches) */
+  reset: () => void;
+}
+
+export function usePaginatedData<T>({
+  fetchFn,
+  getId,
+  deps = [],
+}: PaginatedDataOptions<T>): PaginatedDataResult<T> {
+  const [data, setData] = useState<T[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [apiError, setApiError] = useState<ApiError | null>(null);
+  const [refreshCounter, setRefreshCounter] = useState(0);
+  const [retryCountdown, setRetryCountdown] = useState(0);
+  const [nextCursor, setNextCursor] = useState<string | undefined>();
+  const [hasMore, setHasMore] = useState(true);
+  const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Track seen IDs to deduplicate items across pages
+  const seenIds = useRef(new Set<string>());
+
+  // Clear countdown timer helper
+  const clearCountdown = useCallback(() => {
+    if (countdownRef.current) {
+      clearInterval(countdownRef.current);
+      countdownRef.current = null;
+    }
+  }, []);
+
+  // Clear countdown timer on unmount
+  useEffect(() => {
+    return () => {
+      clearCountdown();
+    };
+  }, [clearCountdown]);
+
+  // Start rate limit countdown
+  const startCountdown = useCallback(
+    (seconds: number) => {
+      setRetryCountdown(seconds);
+      clearCountdown();
+
+      countdownRef.current = setInterval(() => {
+        setRetryCountdown((prev) => {
+          if (prev <= 1) {
+            clearCountdown();
+            return 0;
+          }
+          return prev - 1;
+        });
+      }, 1000);
+    },
+    [clearCountdown]
+  );
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    setApiError(null);
+    // Reset pagination state for fresh fetch
+    seenIds.current.clear();
+
+    const result = await fetchFn();
+
+    if (result.success) {
+      // Populate seen IDs with initial items
+      for (const item of result.items) {
+        seenIds.current.add(getId(item));
+      }
+      setData(result.items);
+      setNextCursor(result.nextCursor);
+      setHasMore(!!result.nextCursor && result.items.length > 0);
+      setRetryCountdown(0);
+      clearCountdown();
+    } else {
+      setError(result.error.message);
+      setApiError(result.error);
+      setHasMore(false);
+
+      // Start countdown for rate limits
+      if (result.error.type === "rate_limit" && result.error.retryAfter) {
+        startCountdown(result.error.retryAfter);
+      }
+    }
+
+    setLoading(false);
+  }, [fetchFn, getId, clearCountdown, startCountdown]);
+
+  // Fetch when dependencies change or refresh is triggered
+  useEffect(() => {
+    fetchData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetchData, refreshCounter, ...deps]);
+
+  const loadMore = useCallback(async () => {
+    if (!nextCursor || loadingMore || !hasMore) return;
+
+    setLoadingMore(true);
+
+    const result = await fetchFn(nextCursor);
+
+    if (result.success) {
+      // Filter out duplicates using seenIds
+      const newItems = result.items.filter(
+        (item) => !seenIds.current.has(getId(item))
+      );
+      for (const item of newItems) {
+        seenIds.current.add(getId(item));
+      }
+
+      setData((prev) => [...prev, ...newItems]);
+      setNextCursor(result.nextCursor);
+      setHasMore(!!result.nextCursor && result.items.length > 0);
+    } else {
+      // On error, don't clear existing data, just stop pagination
+      setHasMore(false);
+    }
+
+    setLoadingMore(false);
+  }, [fetchFn, getId, nextCursor, loadingMore, hasMore]);
+
+  const refresh = useCallback(() => {
+    // Don't allow refresh during rate limit countdown
+    if (retryCountdown > 0) return;
+    // Reset pagination state before refresh
+    setNextCursor(undefined);
+    setHasMore(true);
+    setRefreshCounter((prev) => prev + 1);
+  }, [retryCountdown]);
+
+  const reset = useCallback(() => {
+    setData([]);
+    setNextCursor(undefined);
+    setHasMore(true);
+    seenIds.current.clear();
+  }, []);
+
+  return {
+    data,
+    loading,
+    loadingMore,
+    hasMore,
+    error,
+    apiError,
+    refresh,
+    loadMore,
+    retryBlocked: retryCountdown > 0,
+    retryCountdown,
+    reset,
+  };
+}

--- a/src/hooks/useTimeline.ts
+++ b/src/hooks/useTimeline.ts
@@ -4,10 +4,13 @@
  * with infinite scroll pagination and typed error handling with rate limit detection
  */
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 import type { XClient } from "@/api/client";
 import type { ApiError, TweetData } from "@/api/types";
+
+import { usePaginatedData } from "./usePaginatedData";
+import type { PaginatedFetchResult } from "./usePaginatedData";
 
 export type TimelineTab = "for_you" | "following";
 
@@ -48,141 +51,66 @@ export function useTimeline({
   initialTab = "for_you",
 }: UseTimelineOptions): UseTimelineResult {
   const [tab, setTabInternal] = useState<TimelineTab>(initialTab);
-  const [posts, setPosts] = useState<TweetData[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [loadingMore, setLoadingMore] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [apiError, setApiError] = useState<ApiError | null>(null);
-  const [refreshCounter, setRefreshCounter] = useState(0);
-  const [retryCountdown, setRetryCountdown] = useState(0);
-  const [nextCursor, setNextCursor] = useState<string | undefined>();
-  const [hasMore, setHasMore] = useState(true);
-  const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  // Track seen IDs to deduplicate posts across pages
-  const seenIds = useRef(new Set<string>());
+  // Create fetch function that adapts client API to PaginatedFetchResult
+  const fetchFn = useCallback(
+    async (cursor?: string): Promise<PaginatedFetchResult<TweetData>> => {
+      // Use V2 for initial fetch, V1 for pagination (matches original behavior)
+      const result = cursor
+        ? tab === "for_you"
+          ? await client.getHomeTimeline(30, cursor)
+          : await client.getHomeLatestTimeline(30, cursor)
+        : tab === "for_you"
+          ? await client.getHomeTimelineV2(30)
+          : await client.getHomeLatestTimelineV2(30);
 
-  // Clear countdown timer on unmount
-  useEffect(() => {
-    return () => {
-      if (countdownRef.current) {
-        clearInterval(countdownRef.current);
+      if (result.success) {
+        return {
+          success: true,
+          items: result.tweets,
+          nextCursor: result.nextCursor,
+        };
       }
-    };
-  }, []);
+      return { success: false, error: result.error };
+    },
+    [client, tab]
+  );
 
-  const fetchTimeline = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    setApiError(null);
-    // Reset pagination state for fresh fetch
-    seenIds.current.clear();
+  const getId = useCallback((tweet: TweetData) => tweet.id, []);
 
-    const result =
-      tab === "for_you"
-        ? await client.getHomeTimelineV2(30)
-        : await client.getHomeLatestTimelineV2(30);
+  // Memoize deps array to prevent unnecessary re-renders
+  const deps = useMemo(() => [tab], [tab]);
 
-    if (result.success) {
-      // Populate seen IDs with initial posts
-      for (const tweet of result.tweets) {
-        seenIds.current.add(tweet.id);
-      }
-      setPosts(result.tweets);
-      setNextCursor(result.nextCursor);
-      setHasMore(!!result.nextCursor && result.tweets.length > 0);
-      setRetryCountdown(0);
-      if (countdownRef.current) {
-        clearInterval(countdownRef.current);
-        countdownRef.current = null;
-      }
-    } else {
-      setError(result.error.message);
-      setApiError(result.error);
-      setHasMore(false);
+  const {
+    data: posts,
+    loading,
+    loadingMore,
+    hasMore,
+    error,
+    apiError,
+    refresh,
+    loadMore,
+    retryBlocked,
+    retryCountdown,
+    reset,
+  } = usePaginatedData({
+    fetchFn,
+    getId,
+    deps,
+  });
 
-      // Start countdown for rate limits
-      if (result.error.type === "rate_limit" && result.error.retryAfter) {
-        setRetryCountdown(result.error.retryAfter);
-
-        // Clear any existing countdown
-        if (countdownRef.current) {
-          clearInterval(countdownRef.current);
+  const setTab = useCallback(
+    (newTab: TimelineTab) => {
+      setTabInternal((prev) => {
+        if (prev !== newTab) {
+          // Reset pagination when switching tabs
+          reset();
         }
-
-        // Start new countdown
-        countdownRef.current = setInterval(() => {
-          setRetryCountdown((prev) => {
-            if (prev <= 1) {
-              if (countdownRef.current) {
-                clearInterval(countdownRef.current);
-                countdownRef.current = null;
-              }
-              return 0;
-            }
-            return prev - 1;
-          });
-        }, 1000);
-      }
-    }
-
-    setLoading(false);
-  }, [client, tab]);
-
-  // Fetch when tab changes or refresh is triggered
-  useEffect(() => {
-    fetchTimeline();
-  }, [fetchTimeline, refreshCounter]);
-
-  const loadMore = useCallback(async () => {
-    if (!nextCursor || loadingMore || !hasMore) return;
-
-    setLoadingMore(true);
-
-    const result =
-      tab === "for_you"
-        ? await client.getHomeTimeline(30, nextCursor)
-        : await client.getHomeLatestTimeline(30, nextCursor);
-
-    if (result.success) {
-      // Filter out duplicates using seenIds
-      const newPosts = result.tweets.filter((t) => !seenIds.current.has(t.id));
-      for (const tweet of newPosts) {
-        seenIds.current.add(tweet.id);
-      }
-
-      setPosts((prev) => [...prev, ...newPosts]);
-      setNextCursor(result.nextCursor);
-      setHasMore(!!result.nextCursor && result.tweets.length > 0);
-    } else {
-      // On error, don't clear existing posts, just stop pagination
-      setHasMore(false);
-    }
-
-    setLoadingMore(false);
-  }, [client, tab, nextCursor, loadingMore, hasMore]);
-
-  const setTab = useCallback((newTab: TimelineTab) => {
-    setTabInternal((prev) => {
-      if (prev !== newTab) {
-        // Clear posts and reset pagination when switching tabs
-        setPosts([]);
-        setNextCursor(undefined);
-        setHasMore(true);
-        seenIds.current.clear();
-      }
-      return newTab;
-    });
-  }, []);
-
-  const refresh = useCallback(() => {
-    // Don't allow refresh during rate limit countdown
-    if (retryCountdown > 0) return;
-    // Reset pagination state before refresh
-    setNextCursor(undefined);
-    setHasMore(true);
-    setRefreshCounter((prev) => prev + 1);
-  }, [retryCountdown]);
+        return newTab;
+      });
+    },
+    [reset]
+  );
 
   return {
     tab,
@@ -195,7 +123,7 @@ export function useTimeline({
     apiError,
     refresh,
     loadMore,
-    retryBlocked: retryCountdown > 0,
+    retryBlocked,
     retryCountdown,
   };
 }


### PR DESCRIPTION
Create a generic usePaginatedData hook that consolidates the ~70% duplicated
code from useTimeline, useBookmarks, and useNotifications. The new hook
handles:
- Loading and loadingMore states
- Error and apiError handling with rate limit detection
- Retry countdown timer with setInterval/clearInterval
- Deduplication of items using seenIds ref
- Pagination with cursor-based loading
- Cleanup on unmount

Each original hook now delegates to usePaginatedData with a custom fetchFn
adapter that maps the API responses to the generic PaginatedFetchResult type.