### PR TITLE
fix(bookmarks): Sync bookmark state between detail view and bookmarks list

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -59,11 +59,35 @@ export function App({ client, user: _user }: AppProps) {
     });
   }, [client]);
 
+  // Ref to store BookmarksScreen's removePost function for sync
+  const bookmarksRemovePostRef = useRef<((tweetId: string) => void) | null>(
+    null
+  );
+
+  // Callback to register BookmarksScreen's removePost function
+  const handleRegisterRemovePost = useCallback(
+    (removePost: (tweetId: string) => void) => {
+      bookmarksRemovePostRef.current = removePost;
+    },
+    []
+  );
+
+  // Handle bookmark state changes - sync with BookmarksScreen
+  const handleBookmarkChange = useCallback(
+    (tweetId: string, isBookmarked: boolean) => {
+      if (!isBookmarked && bookmarksRemovePostRef.current) {
+        bookmarksRemovePostRef.current(tweetId);
+      }
+    },
+    []
+  );
+
   // Actions hook for like/bookmark mutations
   const { toggleLike, toggleBookmark, getState, initState } = useActions({
     client,
     onError: (error) => setActionMessage(`Error: ${error}`),
     onSuccess: (message) => setActionMessage(message),
+    onBookmarkChange: handleBookmarkChange,
   });
 
   // Clear action message after 3 seconds
@@ -502,6 +526,7 @@ export function App({ client, user: _user }: AppProps) {
             getActionState={getState}
             initActionState={initState}
             actionMessage={actionMessage}
+            onRegisterRemovePost={handleRegisterRemovePost}
           />
         </box>
 

--- a/src/hooks/useActions.ts
+++ b/src/hooks/useActions.ts
@@ -15,6 +15,8 @@ export interface UseActionsOptions {
   onError?: (error: string) => void;
   /** Callback when an action succeeds - use to show success message */
   onSuccess?: (message: string) => void;
+  /** Callback when bookmark state changes - use to sync bookmark list */
+  onBookmarkChange?: (tweetId: string, isBookmarked: boolean) => void;
 }
 
 export interface TweetActionState {
@@ -50,6 +52,7 @@ export function useActions({
   client,
   onError,
   onSuccess,
+  onBookmarkChange,
 }: UseActionsOptions): UseActionsResult {
   // Track action states by tweet ID
   const [states, setStates] = useState<Map<string, TweetActionState>>(
@@ -173,6 +176,7 @@ export function useActions({
         if (result.success) {
           updateState(tweet.id, { bookmarkPending: false });
           onSuccess?.(newBookmarked ? "Bookmarked" : "Removed bookmark");
+          onBookmarkChange?.(tweet.id, newBookmarked);
         } else {
           // Check if error indicates the tweet was already in the target state
           const lowerError = result.error.toLowerCase();
@@ -219,7 +223,7 @@ export function useActions({
         onError?.(error instanceof Error ? error.message : String(error));
       }
     },
-    [client, states, updateState, onError, onSuccess]
+    [client, states, updateState, onError, onSuccess, onBookmarkChange]
   );
 
   return {

--- a/src/hooks/useBookmarks.ts
+++ b/src/hooks/useBookmarks.ts
@@ -33,6 +33,8 @@ export interface UseBookmarksResult {
   retryBlocked: boolean;
   /** Seconds until retry is allowed (for rate limit countdown) */
   retryCountdown: number;
+  /** Remove a post from the list (used when unbookmarked from detail view) */
+  removePost: (tweetId: string) => void;
 }
 
 export function useBookmarks({
@@ -155,6 +157,11 @@ export function useBookmarks({
     setRefreshCounter((prev) => prev + 1);
   }, [retryCountdown]);
 
+  const removePost = useCallback((tweetId: string) => {
+    setPosts((prev) => prev.filter((post) => post.id !== tweetId));
+    seenIds.current.delete(tweetId);
+  }, []);
+
   return {
     posts,
     loading,
@@ -166,5 +173,6 @@ export function useBookmarks({
     loadMore,
     retryBlocked: retryCountdown > 0,
     retryCountdown,
+    removePost,
   };
 }

--- a/src/screens/BookmarksScreen.tsx
+++ b/src/screens/BookmarksScreen.tsx
@@ -33,6 +33,8 @@ interface BookmarksScreenProps {
   ) => void;
   /** Action feedback message */
   actionMessage?: string | null;
+  /** Callback to register the removePost function for external sync */
+  onRegisterRemovePost?: (removePost: (tweetId: string) => void) => void;
 }
 
 function ScreenHeader() {
@@ -76,6 +78,7 @@ export function BookmarksScreen({
   getActionState,
   initActionState,
   actionMessage,
+  onRegisterRemovePost,
 }: BookmarksScreenProps) {
   const {
     posts,
@@ -88,7 +91,13 @@ export function BookmarksScreen({
     loadMore,
     retryBlocked,
     retryCountdown,
+    removePost,
   } = useBookmarks({ client });
+
+  // Register removePost function for external bookmark sync
+  useEffect(() => {
+    onRegisterRemovePost?.(removePost);
+  }, [onRegisterRemovePost, removePost]);
 
   // Report post count to parent
   useEffect(() => {


### PR DESCRIPTION
When unbookmarking a post from the detail view, the post now correctly
disappears from the Bookmarks screen when navigating back.

Changes:
- Add removePost function to useBookmarks hook
- Add onBookmarkChange callback to useActions hook
- Wire up BookmarksScreen to receive removePost updates via callback
- Connect bookmark state changes in app.tsx to sync both systems