### PR TITLE
refactor(tui): Standardize collapsible footer across all screens

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -351,6 +351,12 @@ export function App({ client, user: _user }: AppProps) {
       }
     }
 
+    // Toggle footer visibility with '?' - works on all screens
+    if (key.sequence === "?") {
+      setShowFooter((prev) => !prev);
+      return;
+    }
+
     // Don't handle other keys during splash or overlay views
     if (showSplash || !isMainView) {
       return;
@@ -364,11 +370,6 @@ export function App({ client, user: _user }: AppProps) {
     // Go to notifications with 'n'
     if (key.name === "n") {
       navigate("notifications");
-    }
-
-    // Toggle footer visibility with '?'
-    if (key.sequence === "?") {
-      setShowFooter((prev) => !prev);
     }
   });
 
@@ -442,6 +443,7 @@ export function App({ client, user: _user }: AppProps) {
               onReplySelect={handlePostSelect}
               getActionState={getState}
               onThreadView={handleThreadView}
+              showFooter={showFooter}
             />
             {showFolderPicker && (
               <box
@@ -480,6 +482,7 @@ export function App({ client, user: _user }: AppProps) {
               focused={currentView === "thread"}
               onBack={handleBackFromThread}
               onSelectTweet={handlePostSelectFromThread}
+              showFooter={showFooter}
             />
           )}
         </box>
@@ -504,6 +507,7 @@ export function App({ client, user: _user }: AppProps) {
               getActionState={getState}
               initActionState={initState}
               actionMessage={actionMessage}
+              showFooter={showFooter}
             />
           )}
         </box>
@@ -549,7 +553,7 @@ export function App({ client, user: _user }: AppProps) {
         </box>
       </box>
 
-      {!showSplash && isMainView && showFooter && <Footer />}
+      {!showSplash && isMainView && <Footer visible={showFooter} />}
 
       {/* Exit confirmation modal */}
       {showExitConfirmation && (

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,9 +2,16 @@ import { useTerminalDimensions } from "@opentui/react";
 
 import { colors } from "@/lib/colors";
 
-type Shortcut = { key: string; label: string };
+export type Keybinding = {
+  key: string;
+  label: string;
+  show?: boolean; // Default true - conditional display
+  activeColor?: string; // Color when active (e.g., for liked/bookmarked states)
+  activeLabel?: string; // Label when active (e.g., "♥" instead of "like")
+  isActive?: boolean; // Whether to show active state
+};
 
-const SHORTCUTS: Shortcut[] = [
+const DEFAULT_BINDINGS: Keybinding[] = [
   { key: "j/k", label: "nav" },
   { key: "l", label: "like" },
   { key: "b", label: "bookmark" },
@@ -12,21 +19,49 @@ const SHORTCUTS: Shortcut[] = [
   { key: "n", label: "notifs" },
   { key: "Tab", label: "view" },
   { key: "q", label: "quit" },
-  { key: "?", label: "hide" },
 ];
 
-function ShortcutItem({ shortcut }: { shortcut: Shortcut }) {
+interface FooterProps {
+  bindings?: Keybinding[];
+  visible?: boolean;
+}
+
+function KeybindingItem({ binding }: { binding: Keybinding }) {
+  const labelColor =
+    binding.isActive && binding.activeColor ? binding.activeColor : colors.dim;
+  const label =
+    binding.isActive && binding.activeLabel
+      ? binding.activeLabel
+      : binding.label;
+
   return (
     <box style={{ flexDirection: "row", flexShrink: 0 }}>
-      <text fg="#ffffff">{shortcut.key}</text>
-      <text fg={colors.dim}> {shortcut.label}</text>
+      <text fg="#ffffff">{binding.key}</text>
+      <text fg={labelColor}> {label}</text>
     </box>
   );
 }
 
-export function Footer() {
+export function Footer({ bindings, visible = true }: FooterProps) {
   const { width } = useTerminalDimensions();
+
+  if (!visible) {
+    return null;
+  }
+
   const borderLine = "─".repeat(width);
+  const effectiveBindings = bindings ?? DEFAULT_BINDINGS;
+
+  // Filter out bindings where show is explicitly false
+  const visibleBindings = effectiveBindings.filter(
+    (b) => b.show === undefined || b.show
+  );
+
+  // Always add the ? keybinding at the end
+  const allBindings: Keybinding[] = [
+    ...visibleBindings,
+    { key: "?", label: "hide" },
+  ];
 
   return (
     <box
@@ -46,8 +81,8 @@ export function Footer() {
           columnGap: 2,
         }}
       >
-        {SHORTCUTS.map((s) => (
-          <ShortcutItem key={s.key} shortcut={s} />
+        {allBindings.map((b) => (
+          <KeybindingItem key={b.key} binding={b} />
         ))}
       </box>
     </box>

--- a/src/components/ThreadView.prototype.tsx
+++ b/src/components/ThreadView.prototype.tsx
@@ -14,6 +14,7 @@ import { useState, useRef, useEffect, useMemo } from "react";
 
 import type { TweetData } from "@/api/types";
 
+import { Footer, type Keybinding } from "@/components/Footer";
 import { colors } from "@/lib/colors";
 import { formatRelativeTime, truncateText } from "@/lib/format";
 
@@ -50,6 +51,8 @@ interface ThreadViewProps {
   onBack?: () => void;
   /** Called when user selects a tweet to view in detail */
   onSelectTweet?: (tweet: TweetData) => void;
+  /** Whether to show the footer */
+  showFooter?: boolean;
 }
 
 /**
@@ -291,6 +294,7 @@ export function ThreadViewPrototype({
   focused = false,
   onBack,
   onSelectTweet,
+  showFooter = true,
 }: ThreadViewProps) {
   const scrollRef = useRef<ScrollBoxRenderable>(null);
   const savedScrollTop = useRef(0);
@@ -452,25 +456,12 @@ export function ThreadViewPrototype({
     </box>
   );
 
-  // Footer with keyboard hints
-  const footer = (
-    <box
-      style={{
-        flexShrink: 0,
-        paddingLeft: 1,
-        paddingRight: 1,
-        paddingTop: 1,
-        flexDirection: "row",
-      }}
-    >
-      <text fg="#ffffff">j/k</text>
-      <text fg={colors.dim}> nav </text>
-      <text fg="#ffffff">Enter</text>
-      <text fg={colors.dim}> view </text>
-      <text fg="#ffffff">h/Esc</text>
-      <text fg={colors.dim}> back</text>
-    </box>
-  );
+  // Footer keybindings
+  const footerBindings: Keybinding[] = [
+    { key: "j/k", label: "nav" },
+    { key: "Enter", label: "view" },
+    { key: "h/Esc", label: "back" },
+  ];
 
   return (
     <box style={{ flexDirection: "column", height: "100%" }}>
@@ -536,7 +527,7 @@ export function ThreadViewPrototype({
           </box>
         )}
       </scrollbox>
-      {footer}
+      <Footer bindings={footerBindings} visible={showFooter} />
     </box>
   );
 }

--- a/src/screens/PostDetailScreen.tsx
+++ b/src/screens/PostDetailScreen.tsx
@@ -11,6 +11,7 @@ import { useState, useRef, useEffect, useCallback } from "react";
 import type { XClient } from "@/api/client";
 import type { TweetData } from "@/api/types";
 
+import { Footer, type Keybinding } from "@/components/Footer";
 import { PostCard } from "@/components/PostCard";
 import { QuotedPostCard } from "@/components/QuotedPostCard";
 import { useListNavigation } from "@/hooks/useListNavigation";
@@ -84,6 +85,8 @@ interface PostDetailScreenProps {
   getActionState?: (tweetId: string) => { liked: boolean; bookmarked: boolean };
   /** Called when user presses 't' to view thread */
   onThreadView?: () => void;
+  /** Whether to show the footer */
+  showFooter?: boolean;
 }
 
 /**
@@ -181,6 +184,7 @@ export function PostDetailScreen({
   onReplySelect,
   getActionState,
   onThreadView,
+  showFooter = true,
 }: PostDetailScreenProps) {
   // Fetch thread context (parent tweet and replies)
   const { parentTweet, replies, loadingParent, loadingReplies } = usePostDetail(
@@ -860,93 +864,44 @@ export function PostDetailScreen({
     </box>
   ) : null;
 
-  // Actions footer
-  const footerContent = (
-    <box
-      style={{
-        flexShrink: 0,
-        paddingLeft: 1,
-        paddingRight: 1,
-        paddingTop: 1,
-        flexDirection: "row",
-        flexWrap: "wrap",
-      }}
-    >
-      <text fg="#ffffff">h/Esc</text>
-      <text fg={colors.dim}> back </text>
-      {showTruncated ? (
-        <>
-          <text fg="#ffffff">e</text>
-          <text fg={colors.dim}> expand </text>
-        </>
-      ) : isExpanded ? (
-        <>
-          <text fg="#ffffff">e</text>
-          <text fg={colors.dim}> collapse </text>
-        </>
-      ) : null}
-      <text fg="#ffffff">x</text>
-      <text fg={colors.dim}> x.com </text>
-      <text fg="#ffffff">b</text>
-      <text fg={isBookmarked ? colors.primary : colors.dim}>
-        {isBookmarked ? " ⚑" : " bookmark"}{" "}
-      </text>
-      {isBookmarked && !hasMentions && (
-        <>
-          <text fg="#ffffff">m</text>
-          <text fg={colors.dim}> folder </text>
-        </>
-      )}
-      <text fg="#ffffff">l</text>
-      <text fg={isLiked ? colors.error : colors.dim}>
-        {isLiked ? " ♥" : " like"}{" "}
-      </text>
-      <text fg="#ffffff">p</text>
-      <text fg={colors.dim}> profile</text>
-      {hasMedia && (
-        <>
-          <text fg="#ffffff"> i</text>
-          <text fg={colors.dim}> preview </text>
-          <text fg="#ffffff">d</text>
-          <text fg={colors.dim}> download</text>
-          {mediaCount > 1 && (
-            <>
-              <text fg="#ffffff"> [/]</text>
-              <text fg={colors.dim}> media</text>
-            </>
-          )}
-        </>
-      )}
-      {hasMentions && !mentionsMode && (
-        <>
-          <text fg="#ffffff"> m</text>
-          <text fg={colors.dim}>
-            {mentionCount === 1 ? " @profile" : " mentions"}
-          </text>
-        </>
-      )}
-      {hasReplies && !repliesMode && (
-        <>
-          <text fg="#ffffff"> r</text>
-          <text fg={colors.dim}> replies</text>
-        </>
-      )}
-      {hasLinks && (
-        <>
-          <text fg="#ffffff"> o</text>
-          <text fg={colors.dim}> link</text>
-          {linkCount > 1 && (
-            <>
-              <text fg="#ffffff"> ,/.</text>
-              <text fg={colors.dim}> nav</text>
-            </>
-          )}
-        </>
-      )}
-      <text fg="#ffffff"> t</text>
-      <text fg={colors.dim}> thread</text>
-    </box>
-  );
+  // Actions footer keybindings
+  const footerBindings: Keybinding[] = [
+    { key: "h/Esc", label: "back" },
+    {
+      key: "e",
+      label: showTruncated ? "expand" : "collapse",
+      show: showTruncated || isExpanded,
+    },
+    { key: "x", label: "x.com" },
+    {
+      key: "b",
+      label: "bookmark",
+      activeLabel: "⚑",
+      activeColor: colors.primary,
+      isActive: isBookmarked,
+    },
+    { key: "m", label: "folder", show: isBookmarked && !hasMentions },
+    {
+      key: "l",
+      label: "like",
+      activeLabel: "♥",
+      activeColor: colors.error,
+      isActive: isLiked,
+    },
+    { key: "p", label: "profile" },
+    { key: "i", label: "preview", show: hasMedia },
+    { key: "d", label: "download", show: hasMedia },
+    { key: "[/]", label: "media", show: hasMedia && mediaCount > 1 },
+    {
+      key: "m",
+      label: mentionCount === 1 ? "@profile" : "mentions",
+      show: hasMentions && !mentionsMode,
+    },
+    { key: "r", label: "replies", show: hasReplies && !repliesMode },
+    { key: "o", label: "link", show: hasLinks },
+    { key: ",/.", label: "nav", show: hasLinks && linkCount > 1 },
+    { key: "t", label: "thread" },
+  ];
 
   // Main layout - always use scrollbox for thread content
   return (
@@ -969,7 +924,7 @@ export function PostDetailScreen({
         {repliesContent}
       </scrollbox>
       {statusContent}
-      {footerContent}
+      <Footer bindings={footerBindings} visible={showFooter} />
     </box>
   );
 }

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -10,6 +10,7 @@ import type { XClient } from "@/api/client";
 import type { TweetData } from "@/api/types";
 import type { TweetActionState } from "@/hooks/useActions";
 
+import { Footer, type Keybinding } from "@/components/Footer";
 import { PostList } from "@/components/PostList";
 import { useUserProfile } from "@/hooks/useUserProfile";
 import { colors } from "@/lib/colors";
@@ -65,6 +66,8 @@ interface ProfileScreenProps {
   ) => void;
   /** Action feedback message */
   actionMessage?: string | null;
+  /** Whether to show the footer */
+  showFooter?: boolean;
 }
 
 export function ProfileScreen({
@@ -78,6 +81,7 @@ export function ProfileScreen({
   getActionState,
   initActionState,
   actionMessage,
+  showFooter = true,
 }: ProfileScreenProps) {
   const { user, tweets, loading, error, refresh } = useUserProfile({
     client,
@@ -221,48 +225,18 @@ export function ProfileScreen({
     </box>
   );
 
-  // Footer - show available actions based on what data exists
-  const footerContent = (
-    <box
-      style={{
-        flexShrink: 0,
-        paddingLeft: 1,
-        paddingRight: 1,
-        flexDirection: "row",
-      }}
-    >
-      <text fg="#ffffff">h/Esc</text>
-      <text fg={colors.dim}> back </text>
-      <text fg="#ffffff">j/k</text>
-      <text fg={colors.dim}> nav </text>
-      <text fg="#ffffff">l</text>
-      <text fg={colors.dim}> like </text>
-      <text fg="#ffffff">b</text>
-      <text fg={colors.dim}> bkmk </text>
-      {user?.profileImageUrl && (
-        <>
-          <text fg="#ffffff">a</text>
-          <text fg={colors.dim}> avatar </text>
-        </>
-      )}
-      {user?.bannerImageUrl && (
-        <>
-          <text fg="#ffffff">v</text>
-          <text fg={colors.dim}> banner </text>
-        </>
-      )}
-      {user?.websiteUrl && (
-        <>
-          <text fg="#ffffff">w</text>
-          <text fg={colors.dim}> web </text>
-        </>
-      )}
-      <text fg="#ffffff">x</text>
-      <text fg={colors.dim}> x.com </text>
-      <text fg="#ffffff">r</text>
-      <text fg={colors.dim}> refresh</text>
-    </box>
-  );
+  // Footer keybindings - show available actions based on what data exists
+  const footerBindings: Keybinding[] = [
+    { key: "h/Esc", label: "back" },
+    { key: "j/k", label: "nav" },
+    { key: "l", label: "like" },
+    { key: "b", label: "bkmk" },
+    { key: "a", label: "avatar", show: !!user?.profileImageUrl },
+    { key: "v", label: "banner", show: !!user?.bannerImageUrl },
+    { key: "w", label: "web", show: !!user?.websiteUrl },
+    { key: "x", label: "x.com" },
+    { key: "r", label: "refresh" },
+  ];
 
   // Loading state
   if (loading) {
@@ -331,7 +305,7 @@ export function ProfileScreen({
           <text fg={colors.muted}>No tweets to display</text>
         </box>
       )}
-      {footerContent}
+      <Footer bindings={footerBindings} visible={showFooter} />
     </box>
   );
 }

--- a/src/screens/ThreadScreen.tsx
+++ b/src/screens/ThreadScreen.tsx
@@ -20,6 +20,7 @@ interface ThreadScreenProps {
   focused?: boolean;
   onBack?: () => void;
   onSelectTweet?: (tweet: TweetData) => void;
+  showFooter?: boolean;
 }
 
 export function ThreadScreen({
@@ -28,6 +29,7 @@ export function ThreadScreen({
   focused = false,
   onBack,
   onSelectTweet,
+  showFooter = true,
 }: ThreadScreenProps) {
   const { ancestors, replyTree, loadingAncestors, loadingReplies, error } =
     useThread({
@@ -73,6 +75,7 @@ export function ThreadScreen({
       focused={focused}
       onBack={onBack}
       onSelectTweet={onSelectTweet}
+      showFooter={showFooter}
     />
   );
 }


### PR DESCRIPTION
## Summary

Unified footer component across all screens (Timeline, Bookmarks, Notifications, Profile, Post Detail, Thread). All footers are now collapsible with `?` key, maintaining state across screen transitions. Supports dynamic keybindings and state-aware styling (active icons for liked/bookmarked posts).

## Changes

- Enhanced `Footer` component with `bindings` prop for custom keybindings
- Global `?` handler works on all screens, not just main views
- Converted inline footers in ProfileScreen, PostDetailScreen, and ThreadView to use shared component
- Dynamic keybindings with conditional display and active states

Fixes #91