### PR TITLE
feat(replies): Add pagination for tweet replies (#83)

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -131,6 +131,8 @@ export interface SearchResult {
   success: boolean;
   tweets?: TweetData[];
   error?: string;
+  /** Pagination cursor for loading more results (e.g., replies) */
+  nextCursor?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements cursor-based pagination for tweet replies using the existing `usePaginatedData` hook pattern. When in reply navigation mode, additional replies load automatically when scrolling near the end (within 3 replies of the end).

## Changes

- Add cursor parameter to `fetchTweetDetail()` for pagination support
- Update `getReplies()` to extract and return `nextCursor` from API response  
- Refactor `usePostDetail` to use `usePaginatedData` for automatic deduplication
- Scroll-triggered loading when navigating near end of replies list
- Shows `(36+)` indicator when more replies are available

## Test Plan

- [x] Navigate to tweet with 100+ replies
- [x] Press `r` to enter reply navigation mode  
- [x] Navigate down with `j` near the end - should load more replies
- [x] Verify reply count updates and shows "+" indicator
- [x] Tests pass (170 + 38 + 24 = 232 tests)
- [x] TypeScript and linting checks pass

Fixes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)