### PR TITLE
feat: Add recursive quote tweet navigation (#59)

### DIFF
--- a/src/components/QuotedPostCard.tsx
+++ b/src/components/QuotedPostCard.tsx
@@ -13,9 +13,14 @@ const QUOTE_BG = "#0d0d14";
 
 interface QuotedPostCardProps {
   post: TweetData;
+  /** Show [t] navigation hint */
+  showNavigationHint?: boolean;
 }
 
-export function QuotedPostCard({ post }: QuotedPostCardProps) {
+export function QuotedPostCard({
+  post,
+  showNavigationHint = false,
+}: QuotedPostCardProps) {
   const displayText = truncateText(post.text, MAX_TEXT_LINES);
 
   return (
@@ -35,6 +40,7 @@ export function QuotedPostCard({ post }: QuotedPostCardProps) {
         <box style={{ flexDirection: "row" }}>
           <text fg={colors.primary}>@{post.author.username}</text>
           <text fg={colors.dim}> · {post.author.name}</text>
+          {showNavigationHint && <text fg={colors.dim}> [u]</text>}
         </box>
 
         {/* Quoted text (truncated) */}


### PR DESCRIPTION
## Summary

Implement recursive quote tweet navigation from post detail view. Users can press `u` or `Enter` to navigate into a quoted tweet, then `h` or `Esc` to return to the parent tweet. Includes circular navigation detection to prevent viewing the same tweet twice and loading state feedback.

## Implementation

- Added `handleQuoteSelect` callback in app.tsx that fetches full tweet data via `getTweet()`
- Handles circular navigation by checking if tweet is already in the stack
- Uses `u`/`Enter` keys for consistency with timeline selection behavior
- Shows `[u]` hint on quoted tweets to indicate navigation is available
- Loading state shows "loading..." in footer while fetching

## Testing

All existing tests pass. Fully backwards compatible - no behavior changes to existing features.