### PR TITLE
feat: Move footer toggle from ? to . key for help screen (#90)

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -12,6 +12,7 @@ This document lists all available keyboard shortcuts in xfeed.
 | `G` | Go to bottom of list |
 | `Enter` / `u` | Select/open item |
 | `h` / `Esc` / `Backspace` | Go back |
+| `.` | Toggle footer visibility |
 | `q` | Quit application |
 
 ## Timeline / Post List

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -461,8 +461,8 @@ export function App({ client, user: _user }: AppProps) {
       }
     }
 
-    // Toggle footer visibility with '?' - works on all screens
-    if (key.sequence === "?") {
+    // Toggle footer visibility with '.' - works on all screens
+    if (key.sequence === ".") {
       setShowFooter((prev) => !prev);
       return;
     }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -57,10 +57,10 @@ export function Footer({ bindings, visible = true }: FooterProps) {
     (b) => b.show === undefined || b.show
   );
 
-  // Always add the ? keybinding at the end
+  // Always add the . keybinding at the end
   const allBindings: Keybinding[] = [
     ...visibleBindings,
-    { key: "?", label: "hide" },
+    { key: ".", label: "hide" },
   ];
 
   return (


### PR DESCRIPTION
## Summary

Move footer visibility toggle from `?` to `.` key to reserve `?` for the upcoming in-app help screen. The `.` key provides a familiar terminal toggle pattern and is more discoverable.

## Changes

- Footer toggle keybinding: `?` → `.`
- Updated Footer UI display to show `. hide`
- Updated keybindings documentation

Fixes #61 (merged into #90).

🤖 Generated with [Claude Code](https://claude.com/claude-code)