### PR TITLE
feat(#117): Improve visual differentiation in post detail with semantic colors

### DIFF
--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -84,12 +84,11 @@ export function PostCard({
       {/* Author line with selection indicator */}
       <box style={{ flexDirection: "row" }}>
         <text fg={colors.primary}>{isSelected ? "> " : "  "}</text>
-        <text fg={colors.primary}>@{post.author.username}</text>
-        <text fg={colors.dim}>
-          {" "}
-          · {post.author.name}
-          {timeAgo ? ` · ${timeAgo}` : ""}
+        <text>
+          <b fg={colors.primary}>{post.author.name}</b>
         </text>
+        <text fg={colors.handle}> @{post.author.username}</text>
+        <text fg={colors.dim}>{timeAgo ? ` · ${timeAgo}` : ""}</text>
       </box>
 
       {/* Post text */}
@@ -155,7 +154,7 @@ export function PostCard({
                   : "GIF";
             const typeColor =
               item.type === "photo"
-                ? colors.primary
+                ? colors.warning
                 : item.type === "video"
                   ? colors.warning
                   : colors.success;

--- a/src/components/QuotedPostCard.tsx
+++ b/src/components/QuotedPostCard.tsx
@@ -38,8 +38,10 @@ export function QuotedPostCard({
       >
         {/* Quoted author line */}
         <box style={{ flexDirection: "row" }}>
-          <text fg={colors.primary}>@{post.author.username}</text>
-          <text fg={colors.dim}> · {post.author.name}</text>
+          <text>
+            <b fg={colors.quoted}>{post.author.name}</b>
+          </text>
+          <text fg={colors.handle}> @{post.author.username}</text>
           {showNavigationHint && <text fg={colors.dim}> [u]</text>}
         </box>
 

--- a/src/lib/colors.ts
+++ b/src/lib/colors.ts
@@ -4,7 +4,7 @@
  */
 
 export const colors = {
-  /** X brand blue - used for primary elements, selection, links */
+  /** X brand blue - used for primary elements, selection, links, main author */
   primary: "#1DA1F2",
 
   /** Success green - used for likes, retweets, success states */
@@ -24,6 +24,18 @@ export const colors = {
 
   /** Dim text color - less prominent than muted */
   dim: "#666666",
+
+  /** Purple - used for @mentions in tweet text */
+  mention: "#9B59B6",
+
+  /** Light blue - used for quoted tweet authors */
+  quoted: "#3498DB",
+
+  /** Gray - used for reply context ("Replying to...") */
+  reply: "#95A5A6",
+
+  /** Muted blue - used for @handles (secondary to name) */
+  handle: "#6B8A9E",
 } as const;
 
 export type ColorKey = keyof typeof colors;

--- a/src/screens/PostDetailScreen.tsx
+++ b/src/screens/PostDetailScreen.tsx
@@ -666,8 +666,8 @@ export function PostDetailScreen({
           <box style={{ flexDirection: "column" }}>
             <box style={{ flexDirection: "row" }}>
               <text fg={colors.dim}>Replying to </text>
-              <text fg={colors.primary}>@{parentTweet.author.username}</text>
-              <text fg={colors.muted}> · {parentTweet.author.name}</text>
+              <text fg={colors.muted}>{parentTweet.author.name}</text>
+              <text fg={colors.reply}> @{parentTweet.author.username}</text>
             </box>
             <box style={{ marginTop: 1 }}>
               <text fg="#aaaaaa">{truncateText(parentTweet.text, 3)}</text>
@@ -681,8 +681,10 @@ export function PostDetailScreen({
   const authorContent = (
     <box style={{ flexDirection: "column", paddingLeft: 1, paddingRight: 1 }}>
       <box style={{ flexDirection: "row" }}>
-        <text fg={colors.primary}>@{tweet.author.username}</text>
-        <text fg="#ffffff"> · {tweet.author.name}</text>
+        <text>
+          <b fg={colors.primary}>{tweet.author.name}</b>
+        </text>
+        <text fg={colors.handle}> @{tweet.author.username}</text>
       </box>
       {fullTimestamp && (
         <box style={{ marginTop: 0 }}>
@@ -696,7 +698,7 @@ export function PostDetailScreen({
   const postContent = (
     <box style={{ marginTop: 1, paddingLeft: 1, paddingRight: 1 }}>
       {hasMentions ? (
-        renderTextWithMentions(displayText, colors.primary, "#ffffff")
+        renderTextWithMentions(displayText, colors.mention, "#ffffff")
       ) : (
         <text fg="#ffffff">{displayText}</text>
       )}
@@ -746,7 +748,7 @@ export function PostDetailScreen({
                 : "GIF";
           const typeColor =
             item.type === "photo"
-              ? colors.primary
+              ? colors.warning
               : item.type === "video"
                 ? colors.warning
                 : colors.success;
@@ -793,7 +795,7 @@ export function PostDetailScreen({
               style={{ flexDirection: "column", marginTop: idx === 0 ? 1 : 0 }}
             >
               <box style={{ flexDirection: "row" }}>
-                <text fg={isSelected ? colors.primary : colors.muted}>
+                <text fg={isSelected ? colors.mention : colors.muted}>
                   {isSelected ? ">" : " "} {link.displayUrl}
                 </text>
               </box>
@@ -823,7 +825,7 @@ export function PostDetailScreen({
           // Single mention - show directly with profile shortcut
           <box style={{ flexDirection: "row" }}>
             <text fg={colors.dim}>Mentions: </text>
-            <text fg={colors.primary}>@{firstMention?.username}</text>
+            <text fg={colors.mention}>@{firstMention?.username}</text>
             {firstMention?.name && (
               <text fg={colors.dim}> · {firstMention.name}</text>
             )}
@@ -848,7 +850,7 @@ export function PostDetailScreen({
                   key={mention.username}
                   style={{ flexDirection: "row", marginTop: idx === 0 ? 1 : 0 }}
                 >
-                  <text fg={isSelected ? colors.primary : colors.muted}>
+                  <text fg={isSelected ? colors.mention : colors.muted}>
                     {isSelected ? ">" : " "} @{mention.username}
                   </text>
                   {mention.name && (
@@ -862,7 +864,7 @@ export function PostDetailScreen({
           // Multiple mentions - collapsed view
           <box style={{ flexDirection: "row" }}>
             <text fg={colors.dim}>Mentions: </text>
-            <text fg={colors.primary}>@{firstMention?.username}</text>
+            <text fg={colors.mention}>@{firstMention?.username}</text>
             <text fg={colors.dim}> +{mentionCount - 1} more (</text>
             <text fg={colors.primary}>m</text>
             <text fg={colors.dim}> to navigate)</text>


### PR DESCRIPTION
## Summary
- Add semantic color variants (mention, quoted, reply, handle) to distinguish usernames in different contexts
- Update author display order (Name first, @handle second) across all views for consistency with X web UI  
- Change image/video colors to orange for better visual hierarchy

## Related Issue
Fixes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)