### PR TITLE
feat(#118): Parse @mentions in profile bio and enable navigation

### DIFF
--- a/.claude/skills/opentui/SKILL.md
+++ b/.claude/skills/opentui/SKILL.md
@@ -405,6 +405,121 @@ function App() {
 }
 ```
 
+## Flex Layout & Spacing (Yoga Engine)
+
+OpenTUI uses the **Yoga layout engine** (same as React Native). Understanding Yoga's behavior is critical for debugging spacing issues.
+
+### Default Flex Behavior
+
+```typescript
+// DEFAULT VALUES (if not specified)
+flexGrow: 0      // Children don't grow to fill space
+flexShrink: 1    // Children CAN shrink (for auto-sized elements)
+flexShrink: 0    // Auto-set when explicit width/height is provided
+
+// alignItems default is "stretch" (cross-axis)
+// justifyContent default is "flex-start" (main-axis)
+```
+
+**Key insight:** If you set explicit `width` or `height`, OpenTUI automatically sets `flexShrink: 0` to prevent unwanted shrinking.
+
+### Preventing Unwanted Spacing
+
+Extra space between flex children often comes from:
+1. Implicit margins/padding (even if not explicitly set)
+2. Flex distribution allocating space to children
+3. Text elements with trailing whitespace
+
+**Solution: Explicit Zero Values**
+
+```tsx
+// When you need tight layout with NO gaps between children
+<box
+  style={{
+    flexDirection: "column",
+    justifyContent: "flex-start",  // Pack children at top
+    marginBottom: 0,               // Explicit zero margin
+    paddingBottom: 0,              // Explicit zero padding
+  }}
+>
+  {/* Child content */}
+</box>
+```
+
+### Real-World Example: Profile Header Spacing Bug
+
+**Problem:** Extra blank line appearing between profile header content and separator line.
+
+**Investigation revealed:**
+- fullHeader box had no explicit bottom margin/padding
+- separator had no explicit top margin/padding
+- Yet a blank line appeared between them
+
+**Solution:**
+```tsx
+// Profile header - pack children at top with explicit zero spacing
+const fullHeader = (
+  <box
+    style={{
+      flexShrink: 0,
+      flexDirection: "column",
+      justifyContent: "flex-start",  // Critical!
+      marginBottom: 0,
+      paddingBottom: 0,
+    }}
+  >
+    {/* header content */}
+  </box>
+);
+
+// Separator - explicit zero margins
+const separator = (
+  <box
+    style={{
+      paddingLeft: 1,
+      paddingRight: 1,
+      flexShrink: 0,
+      marginTop: 0,
+      marginBottom: 0,
+      paddingTop: 0,
+      paddingBottom: 0,
+    }}
+  >
+    <text fg="#444444">{"─".repeat(50)}</text>
+  </box>
+);
+```
+
+### Debugging Spacing Issues
+
+1. **Check for implicit values** - Yoga may apply defaults you don't expect
+2. **Add explicit zeros** - `marginTop: 0, marginBottom: 0, paddingTop: 0, paddingBottom: 0`
+3. **Use justifyContent** - `"flex-start"` packs children at start of main axis
+4. **Check text content** - Use `.trim()` on user-provided text to remove trailing whitespace
+5. **Inspect parent containers** - Spacing can come from parent flex distribution
+
+### Gap Property (Preferred for Intentional Spacing)
+
+When you DO want spacing between children, use `gap` instead of margins:
+
+```tsx
+<box
+  style={{
+    flexDirection: "column",
+    gap: 1,  // 1 line gap between all children
+  }}
+>
+  <text>Item 1</text>
+  <text>Item 2</text>
+  <text>Item 3</text>
+</box>
+```
+
+`gap` is cleaner than adding `marginBottom` to each child because:
+- It doesn't apply to the last child
+- It's a single property on the parent
+- It's more explicit about intent
+
 ## Layout Patterns
 
 ### Full-Height Screen with Header/Footer
@@ -544,6 +659,33 @@ return {
 // CORRECT - memoize with useCallback
 const setSelectedIndexMemo = useCallback((val) => { /* ... */ }, [deps]);
 return { setSelectedIndex: setSelectedIndexMemo };
+```
+
+### 5. Unexpected spacing between flex children
+
+```tsx
+// WRONG - implicit spacing may appear
+<box style={{ flexDirection: "column" }}>
+  <text>Header</text>
+  <text>─────────</text>  {/* Mysterious gap above this! */}
+  <text>Content</text>
+</box>
+
+// CORRECT - explicit zero spacing when needed
+<box
+  style={{
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    marginBottom: 0,
+    paddingBottom: 0,
+  }}
+>
+  <text>Header</text>
+  <box style={{ marginTop: 0, marginBottom: 0, paddingTop: 0, paddingBottom: 0 }}>
+    <text>─────────</text>
+  </box>
+  <text>Content</text>
+</box>
 ```
 
 ## Collapsible Headers (Scroll-Based UI)

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -274,13 +274,14 @@ export function App({ client, user: _user }: AppProps) {
     setPostStack((prev) => prev.slice(0, -1));
   }, [goBack]);
 
-  // State for profile view
-  const [profileUsername, setProfileUsername] = useState<string | null>(null);
+  // State for profile view (stack for nested profile navigation)
+  const [profileStack, setProfileStack] = useState<string[]>([]);
+  const profileUsername = profileStack[profileStack.length - 1] ?? null;
 
-  // Navigate to profile view from post detail
+  // Navigate to profile view from post detail or another profile
   const handleProfileOpen = useCallback(
     (username: string) => {
-      setProfileUsername(username);
+      setProfileStack((prev) => [...prev, username]);
       navigate("profile");
     },
     [navigate]
@@ -300,10 +301,10 @@ export function App({ client, user: _user }: AppProps) {
     setThreadRootTweet(null);
   }, [goBack]);
 
-  // Return from profile to previous view
+  // Return from profile to previous view (pops from profile stack)
   const handleBackFromProfile = useCallback(() => {
     goBack();
-    setProfileUsername(null);
+    setProfileStack((prev) => prev.slice(0, -1));
   }, [goBack]);
 
   // Handle post select from profile (view a user's tweet in detail)
@@ -381,7 +382,7 @@ export function App({ client, user: _user }: AppProps) {
       ) {
         const follower = notification.fromUsers[0];
         if (follower) {
-          setProfileUsername(follower.username);
+          setProfileStack((prev) => [...prev, follower.username]);
           navigate("profile");
         }
         return;
@@ -596,6 +597,7 @@ export function App({ client, user: _user }: AppProps) {
               focused={currentView === "profile"}
               onBack={handleBackFromProfile}
               onPostSelect={handlePostSelectFromProfile}
+              onProfileOpen={handleProfileOpen}
               onLike={toggleLike}
               onBookmark={toggleBookmark}
               getActionState={getState}

--- a/src/lib/text.tsx
+++ b/src/lib/text.tsx
@@ -1,0 +1,76 @@
+/**
+ * Text rendering utilities for xfeed
+ * Shared functions for parsing and highlighting text content
+ */
+
+import type { ReactNode } from "react";
+
+/**
+ * Extract @mentions from text and return array of usernames
+ */
+export function extractMentions(text: string): string[] {
+  const mentionRegex = /@(\w+)/g;
+  const mentions: string[] = [];
+  let match;
+
+  while ((match = mentionRegex.exec(text)) !== null) {
+    const username = match[1];
+    // Avoid duplicates
+    if (username && !mentions.includes(username)) {
+      mentions.push(username);
+    }
+  }
+
+  return mentions;
+}
+
+/**
+ * Render text with @mentions highlighted in a specified color using <span> inside <text>
+ * Uses OpenTUI's text helper components for inline styling
+ */
+export function renderTextWithMentions(
+  text: string,
+  mentionColor: string,
+  textColor: string
+): ReactNode {
+  // Match @username (alphanumeric and underscores)
+  const mentionRegex = /@(\w+)/g;
+  const parts: ReactNode[] = [];
+  let lastIndex = 0;
+  let match;
+  let keyIdx = 0;
+
+  while ((match = mentionRegex.exec(text)) !== null) {
+    // Add text before the mention
+    if (match.index > lastIndex) {
+      parts.push(
+        <span key={`text-${keyIdx++}`} fg={textColor}>
+          {text.slice(lastIndex, match.index)}
+        </span>
+      );
+    }
+    // Add the mention in the specified color
+    parts.push(
+      <span key={`mention-${keyIdx++}`} fg={mentionColor}>
+        {match[0]}
+      </span>
+    );
+    lastIndex = match.index + match[0].length;
+  }
+
+  // Add remaining text after last mention
+  if (lastIndex < text.length) {
+    parts.push(
+      <span key={`text-${keyIdx++}`} fg={textColor}>
+        {text.slice(lastIndex)}
+      </span>
+    );
+  }
+
+  // If no mentions found, just return plain text
+  if (parts.length === 0) {
+    return <text fg={textColor}>{text}</text>;
+  }
+
+  return <text>{parts}</text>;
+}

--- a/src/screens/PostDetailScreen.tsx
+++ b/src/screens/PostDetailScreen.tsx
@@ -25,6 +25,7 @@ import {
   fetchLinkMetadata,
   type LinkMetadata,
 } from "@/lib/media";
+import { renderTextWithMentions } from "@/lib/text";
 
 // Unicode symbols for like/bookmark states
 const HEART_EMPTY = "\u2661"; // ♡
@@ -132,57 +133,6 @@ function formatFullTimestamp(dateString?: string): string {
 function needsTruncation(text: string, maxLines: number): boolean {
   const lines = text.split("\n");
   return lines.length > maxLines;
-}
-
-/**
- * Render text with @mentions highlighted in blue using <span> inside <text>
- * Uses OpenTUI's text helper components for inline styling
- */
-function renderTextWithMentions(
-  text: string,
-  mentionColor: string,
-  textColor: string
-): React.ReactNode {
-  // Match @username (alphanumeric and underscores)
-  const mentionRegex = /@(\w+)/g;
-  const parts: React.ReactNode[] = [];
-  let lastIndex = 0;
-  let match;
-  let keyIdx = 0;
-
-  while ((match = mentionRegex.exec(text)) !== null) {
-    // Add text before the mention
-    if (match.index > lastIndex) {
-      parts.push(
-        <span key={`text-${keyIdx++}`} fg={textColor}>
-          {text.slice(lastIndex, match.index)}
-        </span>
-      );
-    }
-    // Add the mention in blue
-    parts.push(
-      <span key={`mention-${keyIdx++}`} fg={mentionColor}>
-        {match[0]}
-      </span>
-    );
-    lastIndex = match.index + match[0].length;
-  }
-
-  // Add remaining text after last mention
-  if (lastIndex < text.length) {
-    parts.push(
-      <span key={`text-${keyIdx++}`} fg={textColor}>
-        {text.slice(lastIndex)}
-      </span>
-    );
-  }
-
-  // If no mentions found, just return plain text
-  if (parts.length === 0) {
-    return <text fg={textColor}>{text}</text>;
-  }
-
-  return <text>{parts}</text>;
 }
 
 export function PostDetailScreen({


### PR DESCRIPTION
## Summary

Parse @mentions in profile bios, highlight them in blue, and allow navigation to mentioned profiles using the 'm' key. Single mentions open directly; multiple mentions enter navigation mode with j/k navigation.

## Changes

- Extract shared `renderTextWithMentions()` and `extractMentions()` utilities to `src/lib/text.tsx`
- Add mentions parsing and navigation UI to ProfileScreen with proper keyboard handling
- Fix profile-to-profile navigation by using a profile stack (same pattern as post stack)
- Fix extra spacing between profile header and separator with explicit Yoga layout constraints
- Document Yoga layout engine behavior and debugging patterns in OpenTUI skill
- Update navigation documentation with profile stack management and bio mentions flow

## Testing

All existing tests pass. Handles single mention (direct nav), multiple mentions (mode nav), and back navigation from nested profiles correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)