### PR TITLE
refactor(post-detail): Migrate PostDetailScreen to TanStack Query

### DIFF
--- a/src/experiments/index.tsx
+++ b/src/experiments/index.tsx
@@ -36,4 +36,5 @@ export function QueryProvider({ children }: { children: ReactNode }) {
 // Re-export components for external use
 export { TimelineScreenExperimental } from "./TimelineScreenExperimental";
 export { useTimelineQuery } from "./use-timeline-query";
+export { usePostDetailQuery } from "./use-post-detail-query";
 export { createQueryClient, queryKeys } from "./query-client";

--- a/src/experiments/use-post-detail-query.ts
+++ b/src/experiments/use-post-detail-query.ts
@@ -1,0 +1,187 @@
+/**
+ * usePostDetailQuery - TanStack Query hook for post detail fetching
+ *
+ * Features:
+ * - Uses initial tweet data from navigation (avoids refetch)
+ * - Fetches parent tweet if this is a reply
+ * - Infinite query for paginated replies
+ * - Deduplication across reply pages
+ */
+
+import {
+  useInfiniteQuery,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { useEffect, useMemo } from "react";
+
+import type { XClient } from "@/api/client";
+import type { ApiError, TweetData } from "@/api/types";
+
+import { queryKeys } from "./query-client";
+
+interface RepliesPage {
+  replies: TweetData[];
+  nextCursor?: string;
+}
+
+export interface UsePostDetailQueryOptions {
+  /** X API client */
+  client: XClient;
+  /** Initial tweet data (passed from timeline for immediate display) */
+  tweet: TweetData;
+}
+
+export interface UsePostDetailQueryResult {
+  /** The main tweet data */
+  tweet: TweetData;
+  /** Parent tweet if this is a reply (null if not a reply or still loading) */
+  parentTweet: TweetData | null;
+  /** Replies to this tweet */
+  replies: TweetData[];
+  /** Whether parent tweet is loading */
+  loadingParent: boolean;
+  /** Whether replies are loading (initial load) */
+  loadingReplies: boolean;
+  /** Whether more replies are loading (pagination) */
+  loadingMoreReplies: boolean;
+  /** Whether there are more replies to load */
+  hasMoreReplies: boolean;
+  /** Error fetching parent (if any) */
+  parentError: string | null;
+  /** Error fetching replies (if any) */
+  repliesError: string | null;
+  /** Refresh replies (resets to first page) */
+  refreshReplies: () => void;
+  /** Load more replies (pagination) */
+  loadMoreReplies: () => void;
+}
+
+/**
+ * Fetch replies page from X API
+ */
+async function fetchRepliesPage(
+  client: XClient,
+  tweetId: string,
+  cursor?: string
+): Promise<RepliesPage> {
+  const result = await client.getReplies(tweetId, cursor);
+
+  if (!result.success) {
+    const error: ApiError = {
+      type: "unknown",
+      message: result.error ?? "Failed to fetch replies",
+    };
+    throw error;
+  }
+
+  return {
+    replies: result.tweets ?? [],
+    nextCursor: result.nextCursor,
+  };
+}
+
+/**
+ * Deduplicate replies across all pages
+ */
+function deduplicateReplies(pages: RepliesPage[]): TweetData[] {
+  const seen = new Set<string>();
+  const result: TweetData[] = [];
+
+  for (const page of pages) {
+    for (const reply of page.replies) {
+      if (!seen.has(reply.id)) {
+        seen.add(reply.id);
+        result.push(reply);
+      }
+    }
+  }
+
+  return result;
+}
+
+export function usePostDetailQuery({
+  client,
+  tweet,
+}: UsePostDetailQueryOptions): UsePostDetailQueryResult {
+  const queryClient = useQueryClient();
+
+  // Populate the cache with the initial tweet data from navigation
+  // This prevents an unnecessary refetch when we already have the data
+  useEffect(() => {
+    queryClient.setQueryData(queryKeys.tweet.detail(tweet.id), tweet);
+  }, [queryClient, tweet.id, tweet]);
+
+  // Fetch parent tweet if this is a reply
+  const parentTweetId = tweet.inReplyToStatusId;
+  const {
+    data: parentTweet,
+    isLoading: loadingParent,
+    error: parentQueryError,
+  } = useQuery({
+    queryKey: queryKeys.tweet.detail(parentTweetId ?? ""),
+    queryFn: async () => {
+      if (!parentTweetId) return null;
+      const result = await client.getTweet(parentTweetId);
+      if (!result.success) {
+        const error: ApiError = {
+          type: "unknown",
+          message: result.error ?? "Failed to fetch parent tweet",
+        };
+        throw error;
+      }
+      return result.tweet ?? null;
+    },
+    enabled: !!parentTweetId,
+  });
+
+  // Infinite query for paginated replies
+  const {
+    data: repliesData,
+    isLoading: loadingReplies,
+    isFetchingNextPage: loadingMoreReplies,
+    hasNextPage,
+    error: repliesQueryError,
+    fetchNextPage,
+    refetch: refetchReplies,
+  } = useInfiniteQuery({
+    queryKey: queryKeys.tweet.replies(tweet.id),
+    queryFn: async ({ pageParam }) => {
+      return fetchRepliesPage(client, tweet.id, pageParam);
+    },
+    getNextPageParam: (lastPage) => lastPage.nextCursor,
+    initialPageParam: undefined as string | undefined,
+  });
+
+  // Flatten and deduplicate replies from all pages
+  const replies = useMemo(() => {
+    if (!repliesData?.pages) return [];
+    return deduplicateReplies(repliesData.pages);
+  }, [repliesData?.pages]);
+
+  // Extract error messages - handle both ApiError and regular Error
+  const parentError = parentQueryError
+    ? ((parentQueryError as unknown as ApiError).message ??
+      (parentQueryError instanceof Error ? parentQueryError.message : null) ??
+      "Failed to fetch parent tweet")
+    : null;
+  const repliesError = repliesQueryError
+    ? ((repliesQueryError as unknown as ApiError).message ??
+      (repliesQueryError instanceof Error ? repliesQueryError.message : null) ??
+      "Failed to fetch replies")
+    : null;
+
+  return {
+    tweet,
+    parentTweet: parentTweet ?? null,
+    replies,
+    loadingParent: !!parentTweetId && loadingParent,
+    loadingReplies,
+    loadingMoreReplies,
+    hasMoreReplies: hasNextPage ?? false,
+    parentError,
+    repliesError,
+    refreshReplies: () => refetchReplies(),
+    loadMoreReplies: () => fetchNextPage(),
+  };
+}

--- a/src/screens/PostDetailScreen.tsx
+++ b/src/screens/PostDetailScreen.tsx
@@ -14,8 +14,8 @@ import type { TweetData } from "@/api/types";
 import { Footer, type Keybinding } from "@/components/Footer";
 import { PostCard } from "@/components/PostCard";
 import { QuotedPostCard } from "@/components/QuotedPostCard";
+import { usePostDetailQuery } from "@/experiments/use-post-detail-query";
 import { useListNavigation } from "@/hooks/useListNavigation";
-import { usePostDetail } from "@/hooks/usePostDetail";
 import { colors } from "@/lib/colors";
 import { formatCount, truncateText } from "@/lib/format";
 import {
@@ -166,7 +166,7 @@ export function PostDetailScreen({
     loadingMoreReplies,
     hasMoreReplies,
     loadMoreReplies,
-  } = usePostDetail({ client, tweet });
+  } = usePostDetailQuery({ client, tweet });
   const [isExpanded, setIsExpanded] = useState(false);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [mediaIndex, setMediaIndex] = useState(0);


### PR DESCRIPTION
## Summary

Implement `usePostDetailQuery` hook using TanStack Query to replace the vanilla `usePostDetail` hook. Uses initial tweet data from navigation to avoid refetch, implements parent tweet fetching with conditional enabling, and uses infinite queries for paginated replies with automatic deduplication.

## Test Plan

- All existing tests pass
- Type checking passes
- Lint checks pass

Fixes #158