### PR TITLE
feat(cli): Block Apple Terminal and show alternative recommendations

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,30 @@ import { cac } from "cac";
 
 import type { BrowserId } from "@/config/types";
 
+/**
+ * Check if running in Apple Terminal which has limited color support
+ * Blocks execution since the UI is unusable without true color
+ */
+function checkTerminalCompatibility(): void {
+  const termProgram = process.env.TERM_PROGRAM;
+  const colorterm = process.env.COLORTERM;
+
+  // Apple Terminal doesn't set COLORTERM and has limited true color support
+  if (termProgram === "Apple_Terminal" && colorterm !== "truecolor") {
+    console.error(
+      "\x1b[31m✗ Apple Terminal is not supported.\x1b[0m\n\n" +
+        "  xfeed requires a terminal with true color (24-bit) support.\n" +
+        "  Apple Terminal only supports 256 colors, causing display issues.\n\n" +
+        "  \x1b[1mRecommended terminals:\x1b[0m\n" +
+        "    • Ghostty  - https://ghostty.org\n" +
+        "    • iTerm2   - https://iterm2.com\n" +
+        "    • Kitty    - https://sw.kovidgoyal.net/kitty\n" +
+        "    • Warp     - https://warp.dev\n"
+    );
+    process.exit(1);
+  }
+}
+
 import { App } from "@/app";
 import { detectAvailableBrowsers, isInteractive } from "@/auth/browser-detect";
 import { promptBrowserSelection } from "@/auth/browser-picker";
@@ -50,6 +74,9 @@ cli
       skipValidation?: boolean;
       resetAuth?: boolean;
     }) => {
+      // Check terminal compatibility first
+      checkTerminalCompatibility();
+
       // Handle --reset-auth
       if (options.resetAuth) {
         clearBrowserPreference();


### PR DESCRIPTION
## Summary
- Block Apple Terminal at startup since it lacks true color support
- Show helpful error with recommended terminals (Ghostty, iTerm2, Kitty, Warp)

## Context
Apple Terminal only supports 256 colors, causing severe display issues (see #172). Instead of a warning, we now block execution entirely and guide users to proper terminals.

## Test plan
- [ ] Run xfeed in Apple Terminal → should see error and exit
- [ ] Run xfeed in iTerm2/Ghostty/Kitty → should work normally


🤖 Generated with [Claude Code](https://claude.com/claude-code)