### PR TITLE
feat(ci): Add release workflow and npm publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - run: bun install --frozen-lockfile
+
+      - name: Run tests
+        run: bun run test
+
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true

--- a/package.json
+++ b/package.json
@@ -35,5 +35,12 @@
   },
   "engines": {
     "bun": ">= 1.0"
-  }
+  },
+  "files": [
+    "src",
+    "vendor"
+  ],
+  "bundledDependencies": [
+    "@steipete/sweet-cookie"
+  ]
 }


### PR DESCRIPTION
## Summary
- Add `release.yml` workflow to publish to npm on tag push
- Add `bundledDependencies` for patched sweet-cookie vendor package
- Add `files` field to include `src` and `vendor` in npm package

## How it works
1. Push a tag: `git tag v0.1.0 && git push origin v0.1.0`
2. CI runs tests
3. CI publishes to npm
4. CI creates GitHub Release

## Users install with
```bash
bun install -g xfeed
xfeed
```

## Setup done
- ✅ NPM_TOKEN secret added

## Test plan
- [ ] Merge PR
- [ ] Create tag `v0.1.0` and push
- [ ] Verify release workflow completes
- [ ] Test `bun install -g xfeed`

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)