### PR TITLE
feat: Restore sync-context script and document reference repos

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,10 +76,16 @@ type Result<T, E = string> = { ok: true; value: T } | { ok: false; error: E }
 
 ### Reference Code
 
-The `.context/repos/` directory contains reference implementations:
-- `bird/` - CLI tool with XClient implementation
+Since OpenTUI is a very new library, reference repos in `.context/repos/` are essential for development. If the directory doesn't exist, run:
+
+```bash
+bun run sync-context
+```
+
+This reads from `conductor.json` and clones/updates:
 - `opentui/` - OpenTUI framework (core + react)
-- `x-client-transaction-id/` - Transaction ID generator for API mutations (see `docs/x-client-transaction-id.md`)
+- `bird/` - X API client reference implementation
+- `x-client-transaction-id/` - Transaction ID generator for X API mutations (see `docs/x-client-transaction-id.md`)
 
 ## Tech Stack
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,16 @@ All pull requests must reference a GitHub issue (e.g., `#123` or `Fixes #123`) i
    bun run start
    ```
 
+### Reference Repos
+
+Since OpenTUI is a very new library, I strongly suggest cloning reference repos while developing new features. Use the sync-context script to clone them:
+
+```bash
+bun run sync-context
+```
+
+This reads from `conductor.json` and clones repos to `.context/repos/`. See [conductor.json docs](https://docs.conductor.build/core/conductor-json) for configuration details.
+
 ## Commands
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "bun test src/api src/lib && bun test src/auth/cookies.test.ts && bun test --preload ./src/auth/check.test.preload.ts src/auth/check.test.ts",
     "test:watch": "bun test --watch",
     "test:coverage": "bun test --coverage src/api src/lib && bun test --coverage src/auth/cookies.test.ts && bun test --coverage --preload ./src/auth/check.test.preload.ts src/auth/check.test.ts",
+    "sync-context": "bun scripts/sync-context.ts",
     "prepare": "lefthook install"
   },
   "dependencies": {

--- a/scripts/sync-context.ts
+++ b/scripts/sync-context.ts
@@ -1,0 +1,78 @@
+/**
+ * Sync reference repos to .context/repos for AI context
+ * Reads conductor.json and clones/updates configured repos
+ */
+
+import { $ } from "bun";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+interface RepoConfig {
+  name: string;
+  url: string;
+  description?: string;
+}
+
+interface ConductorConfig {
+  context?: {
+    repos?: RepoConfig[];
+  };
+}
+
+const CONTEXT_DIR = ".context/repos";
+
+async function syncRepo(repo: RepoConfig): Promise<void> {
+  const repoPath = join(CONTEXT_DIR, repo.name);
+
+  if (existsSync(repoPath)) {
+    // Update existing repo
+    console.log(`Updating ${repo.name}...`);
+    try {
+      await $`git -C ${repoPath} fetch --depth 1 origin`.quiet();
+      await $`git -C ${repoPath} reset --hard origin/HEAD`.quiet();
+      console.log(`  ✓ ${repo.name} updated`);
+    } catch (error) {
+      console.error(`  ✗ Failed to update ${repo.name}:`, error);
+    }
+  } else {
+    // Clone new repo
+    console.log(`Cloning ${repo.name}...`);
+    try {
+      await $`git clone --depth 1 ${repo.url} ${repoPath}`.quiet();
+      console.log(`  ✓ ${repo.name} cloned`);
+    } catch (error) {
+      console.error(`  ✗ Failed to clone ${repo.name}:`, error);
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  // Read conductor.json
+  const configPath = join(process.cwd(), "conductor.json");
+  if (!existsSync(configPath)) {
+    console.log("No conductor.json found, skipping context sync");
+    return;
+  }
+
+  const config: ConductorConfig = await Bun.file(configPath).json();
+  const repos = config.context?.repos ?? [];
+
+  if (repos.length === 0) {
+    console.log("No repos configured in conductor.json");
+    return;
+  }
+
+  // Ensure .context/repos exists
+  await $`mkdir -p ${CONTEXT_DIR}`.quiet();
+
+  console.log(`Syncing ${repos.length} reference repos to ${CONTEXT_DIR}/\n`);
+
+  // Sync all repos
+  for (const repo of repos) {
+    await syncRepo(repo);
+  }
+
+  console.log("\nContext repos synced!");
+}
+
+main().catch(console.error);


### PR DESCRIPTION
Restore the sync-context script that was accidentally deleted during the scripts folder cleanup. This script clones/updates reference repos to `.context/repos/` based on `conductor.json`.

Updated CLAUDE.md and CONTRIBUTING.md to document how to use the script for developers working with OpenTUI.