### PR TITLE
Security: Enforce 0o600 permissions on config file

### DIFF
--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,4 +1,10 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 
@@ -38,6 +44,7 @@ export function saveConfig(config: XfeedConfig): void {
     mkdirSync(CONFIG_DIR, { recursive: true });
   }
   writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2) + "\n");
+  chmodSync(CONFIG_PATH, 0o600);
 }
 
 /**


### PR DESCRIPTION
Enforces restrictive file permissions on the config file that stores auth tokens, ensuring they are only readable by the owner.

The config file at `~/.config/xfeed/config.json` contains sensitive authentication tokens. This fix applies 0o600 permissions after writing, matching the security claim in the documentation and following best practices used by tools like OpenAI Codex and sst/opencode.

All config write operations (`saveConfig`, `updateConfig`, `clearBrowserPreference`) now enforce these permissions.

Fixes #134