### PR TITLE
feat(#51): Enable text selection and copying in post views

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/experiments";
 import { useActions } from "@/hooks/useActions";
 import { useNavigation } from "@/hooks/useNavigation";
+import { copyToClipboard } from "@/lib/clipboard";
 import { BookmarksScreen } from "@/screens/BookmarksScreen";
 import { NotificationsScreen } from "@/screens/NotificationsScreen";
 import { PostDetailScreen } from "@/screens/PostDetailScreen";
@@ -400,6 +401,22 @@ function AppContent({ client, user }: AppProps) {
   );
 
   useKeyboard((key) => {
+    // Handle copy with 'c' - Cmd+C is intercepted by terminal
+    if (key.name === "c") {
+      const selection = renderer.getSelection();
+      if (selection) {
+        const text = selection.getSelectedText();
+        if (text) {
+          copyToClipboard(text).then((result) => {
+            if (result.success) {
+              setActionMessage("Copied to clipboard");
+            }
+          });
+          return;
+        }
+      }
+    }
+
     // Don't handle keys when modals are showing - they handle their own keyboard
     if (isModalOpen) {
       return;

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -93,7 +93,9 @@ export function PostCard({
 
       {/* Post text */}
       <box style={{ marginTop: 1, paddingLeft: 2 }}>
-        <text fg="#ffffff">{displayText}</text>
+        <text fg="#ffffff" selectable selectionBg="#264F78">
+          {displayText}
+        </text>
       </box>
 
       {/* Quoted tweet (if present) */}

--- a/src/components/QuotedPostCard.tsx
+++ b/src/components/QuotedPostCard.tsx
@@ -47,7 +47,9 @@ export function QuotedPostCard({
 
         {/* Quoted text (truncated) */}
         <box style={{ marginTop: 1 }}>
-          <text fg="#aaaaaa">{displayText}</text>
+          <text fg="#aaaaaa" selectable selectionBg="#264F78">
+            {displayText}
+          </text>
         </box>
       </box>
     </box>

--- a/src/components/ReplyPreviewCard.tsx
+++ b/src/components/ReplyPreviewCard.tsx
@@ -72,7 +72,9 @@ export function ReplyPreviewCard({
 
         {/* Reply text (truncated) */}
         <box style={{ marginTop: 1 }}>
-          <text fg="#aaaaaa">{displayText}</text>
+          <text fg="#aaaaaa" selectable selectionBg="#264F78">
+            {displayText}
+          </text>
         </box>
       </box>
     </box>

--- a/src/lib/clipboard.ts
+++ b/src/lib/clipboard.ts
@@ -1,0 +1,57 @@
+/**
+ * Clipboard utilities for copying text to system clipboard
+ */
+
+import { spawn } from "node:child_process";
+import { platform } from "node:os";
+
+export type ClipboardResult =
+  | { success: true; message: string }
+  | { success: false; error: string };
+
+/**
+ * Copy text to system clipboard
+ * Uses platform-specific commands: pbcopy (macOS), xclip (Linux), clip (Windows)
+ */
+export async function copyToClipboard(text: string): Promise<ClipboardResult> {
+  const os = platform();
+
+  let command: string;
+  let args: string[];
+
+  switch (os) {
+    case "darwin":
+      command = "pbcopy";
+      args = [];
+      break;
+    case "linux":
+      command = "xclip";
+      args = ["-selection", "clipboard"];
+      break;
+    case "win32":
+      command = "clip";
+      args = [];
+      break;
+    default:
+      return { success: false, error: `Unsupported platform: ${os}` };
+  }
+
+  return new Promise((resolve) => {
+    const proc = spawn(command, args, { stdio: ["pipe", "ignore", "ignore"] });
+
+    proc.on("error", (err) => {
+      resolve({ success: false, error: `Failed to copy: ${err.message}` });
+    });
+
+    proc.on("close", (code) => {
+      if (code === 0) {
+        resolve({ success: true, message: "Copied to clipboard" });
+      } else {
+        resolve({ success: false, error: `Copy failed with code ${code}` });
+      }
+    });
+
+    proc.stdin?.write(text);
+    proc.stdin?.end();
+  });
+}

--- a/src/lib/text.tsx
+++ b/src/lib/text.tsx
@@ -69,8 +69,16 @@ export function renderTextWithMentions(
 
   // If no mentions found, just return plain text
   if (parts.length === 0) {
-    return <text fg={textColor}>{text}</text>;
+    return (
+      <text fg={textColor} selectable selectionBg="#264F78">
+        {text}
+      </text>
+    );
   }
 
-  return <text>{parts}</text>;
+  return (
+    <text selectable selectionBg="#264F78">
+      {parts}
+    </text>
+  );
 }

--- a/src/screens/PostDetailScreen.tsx
+++ b/src/screens/PostDetailScreen.tsx
@@ -620,7 +620,9 @@ export function PostDetailScreen({
               <text fg={colors.reply}> @{parentTweet.author.username}</text>
             </box>
             <box style={{ marginTop: 1 }}>
-              <text fg="#aaaaaa">{truncateText(parentTweet.text, 3)}</text>
+              <text fg="#aaaaaa" selectable selectionBg="#264F78">
+                {truncateText(parentTweet.text, 3)}
+              </text>
             </box>
           </box>
         ) : null}
@@ -650,7 +652,9 @@ export function PostDetailScreen({
       {hasMentions ? (
         renderTextWithMentions(displayText, colors.mention, "#ffffff")
       ) : (
-        <text fg="#ffffff">{displayText}</text>
+        <text fg="#ffffff" selectable selectionBg="#264F78">
+          {displayText}
+        </text>
       )}
     </box>
   );


### PR DESCRIPTION
## Summary
- Add text selection with visual feedback (blue highlight) for tweet text across all views
- Implement copy to clipboard functionality via 'c' key (Cmd+C intercepted by terminal)
- Create cross-platform clipboard utility supporting macOS, Linux, and Windows
- Selected text shows "Copied to clipboard" confirmation message

## Changes
- New clipboard utility (`src/lib/clipboard.ts`) with cross-platform support
- Global copy handler in App for 'c' key that uses `renderer.getSelection()`
- Added `selectable` and `selectionBg` props to text elements in PostCard, PostDetailScreen, QuotedPostCard, ReplyPreviewCard, and renderTextWithMentions()

## Test Plan
- Select text by clicking and dragging in any tweet
- Press 'c' to copy selected text
- Verify "Copied to clipboard" message appears
- Paste text elsewhere to confirm it was copied correctly
- Test works in both timeline and post detail views

🤖 Generated with Claude Code