### PR TITLE
feat(config): Add TOML-based user preferences

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "oxlint src && oxfmt --check src",
     "lint:fix": "oxlint --fix src && oxfmt --write src",
-    "test": "bun test src/api src/lib && bun test src/auth/cookies.test.ts && bun test --preload ./src/auth/check.test.preload.ts src/auth/check.test.ts",
+    "test": "bun test src/api src/lib src/config/toml.test.ts && bun test src/auth/cookies.test.ts && bun test --preload ./src/auth/check.test.preload.ts src/auth/check.test.ts && bun test --preload ./src/config/preferences.test.preload.ts src/config/preferences.test.ts",
     "test:watch": "bun test --watch",
     "test:coverage": "bun test --coverage src/api src/lib && bun test --coverage src/auth/cookies.test.ts && bun test --coverage --preload ./src/auth/check.test.preload.ts src/auth/check.test.ts",
     "sync-context": "bun scripts/sync-context.ts",

--- a/src/config/preferences-types.ts
+++ b/src/config/preferences-types.ts
@@ -1,0 +1,36 @@
+import type { TimelineTab } from "@/experiments/use-timeline-query";
+
+/**
+ * Timeline preferences section
+ */
+export interface TimelinePreferences {
+  /**
+   * Default tab to show when opening the timeline
+   * @default "for_you"
+   */
+  default_tab: TimelineTab;
+}
+
+/**
+ * User preferences stored in ~/.config/xfeed/preferences.toml
+ *
+ * All fields use defaults if missing or invalid.
+ * Invalid values trigger warnings to stderr.
+ */
+export interface UserPreferences {
+  timeline: TimelinePreferences;
+}
+
+/**
+ * Default preferences - used when file is missing or values are invalid
+ */
+export const DEFAULT_PREFERENCES: UserPreferences = {
+  timeline: {
+    default_tab: "for_you",
+  },
+};
+
+/**
+ * Valid values for timeline.default_tab
+ */
+export const VALID_TIMELINE_TABS = ["for_you", "following"] as const;

--- a/src/config/preferences.test.preload.ts
+++ b/src/config/preferences.test.preload.ts
@@ -1,0 +1,29 @@
+/**
+ * Preload file for preferences.test.ts
+ * Sets up module mocks BEFORE any imports occur.
+ *
+ * Run with: bun test --preload ./src/config/preferences.test.preload.ts src/config/preferences.test.ts
+ */
+
+import { mock } from "bun:test";
+
+// Mock file content - tests can update this
+export let mockFileExists = false;
+export let mockFileContent = "";
+
+// Helper functions to update mocks from tests
+export function setMockFile(exists: boolean, content = "") {
+  mockFileExists = exists;
+  mockFileContent = content;
+}
+
+export function resetMocks() {
+  mockFileExists = false;
+  mockFileContent = "";
+}
+
+// Mock node:fs module
+mock.module("node:fs", () => ({
+  existsSync: () => mockFileExists,
+  readFileSync: () => mockFileContent,
+}));

--- a/src/config/preferences.test.ts
+++ b/src/config/preferences.test.ts
@@ -1,0 +1,125 @@
+// @ts-nocheck - Test file with module mocking
+/**
+ * Unit tests for preferences.ts
+ * Tests loading and validation of user preferences
+ *
+ * NOTE: This test uses a preload file for module mocking to avoid
+ * polluting other test files. Run with:
+ *   bun test --preload ./src/config/preferences.test.preload.ts src/config/preferences.test.ts
+ */
+
+import { beforeEach, describe, expect, it } from "bun:test";
+
+import { resetMocks, setMockFile } from "./preferences.test.preload";
+
+// Import the module under test (mocks are set up by preload)
+const { loadPreferences, getPreferencesPath } = await import("./preferences");
+const { DEFAULT_PREFERENCES } = await import("./preferences-types");
+
+describe("preferences", () => {
+  beforeEach(() => {
+    resetMocks();
+  });
+
+  describe("loadPreferences", () => {
+    it("returns defaults when file does not exist", () => {
+      setMockFile(false);
+
+      const result = loadPreferences();
+
+      expect(result.preferences).toEqual(DEFAULT_PREFERENCES);
+      expect(result.warnings).toEqual([]);
+    });
+
+    it("returns defaults for empty file", () => {
+      setMockFile(true, "");
+
+      const result = loadPreferences();
+
+      expect(result.preferences).toEqual(DEFAULT_PREFERENCES);
+      expect(result.warnings).toEqual([]);
+    });
+
+    it("returns defaults for whitespace-only file", () => {
+      setMockFile(true, "   \n  \n  ");
+
+      const result = loadPreferences();
+
+      expect(result.preferences).toEqual(DEFAULT_PREFERENCES);
+      expect(result.warnings).toEqual([]);
+    });
+
+    it("parses valid timeline.default_tab = for_you", () => {
+      setMockFile(true, '[timeline]\ndefault_tab = "for_you"');
+
+      const result = loadPreferences();
+
+      expect(result.preferences.timeline.default_tab).toBe("for_you");
+      expect(result.warnings).toEqual([]);
+    });
+
+    it("parses valid timeline.default_tab = following", () => {
+      setMockFile(true, '[timeline]\ndefault_tab = "following"');
+
+      const result = loadPreferences();
+
+      expect(result.preferences.timeline.default_tab).toBe("following");
+      expect(result.warnings).toEqual([]);
+    });
+
+    it("warns on invalid timeline.default_tab and uses default", () => {
+      setMockFile(true, '[timeline]\ndefault_tab = "invalid"');
+
+      const result = loadPreferences();
+
+      expect(result.preferences.timeline.default_tab).toBe("for_you");
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0]).toContain("Invalid timeline.default_tab");
+      expect(result.warnings[0]).toContain('"invalid"');
+      expect(result.warnings[0]).toContain("for_you, following");
+    });
+
+    it("ignores unknown sections", () => {
+      setMockFile(
+        true,
+        '[unknown]\nfoo = "bar"\n\n[timeline]\ndefault_tab = "following"'
+      );
+
+      const result = loadPreferences();
+
+      expect(result.preferences.timeline.default_tab).toBe("following");
+      expect(result.warnings).toEqual([]);
+    });
+
+    it("ignores unknown keys in known sections", () => {
+      setMockFile(
+        true,
+        '[timeline]\nunknown_key = "value"\ndefault_tab = "following"'
+      );
+
+      const result = loadPreferences();
+
+      expect(result.preferences.timeline.default_tab).toBe("following");
+      expect(result.warnings).toEqual([]);
+    });
+
+    it("handles file with only comments", () => {
+      setMockFile(true, "# This is a comment\n# Another comment");
+
+      const result = loadPreferences();
+
+      expect(result.preferences).toEqual(DEFAULT_PREFERENCES);
+      expect(result.warnings).toEqual([]);
+    });
+  });
+
+  describe("getPreferencesPath", () => {
+    it("returns path ending with preferences.toml", () => {
+      const path = getPreferencesPath();
+
+      expect(path).toContain("preferences.toml");
+      expect(path).toContain(".config");
+      expect(path).toContain("xfeed");
+    });
+  });
+});

--- a/src/config/preferences.ts
+++ b/src/config/preferences.ts
@@ -1,0 +1,100 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+import type { TimelineTab } from "@/experiments/use-timeline-query";
+
+import {
+  DEFAULT_PREFERENCES,
+  VALID_TIMELINE_TABS,
+  type UserPreferences,
+} from "./preferences-types";
+import { parseToml } from "./toml";
+
+const CONFIG_DIR = path.join(homedir(), ".config", "xfeed");
+const PREFERENCES_PATH = path.join(CONFIG_DIR, "preferences.toml");
+
+/**
+ * Result of loading preferences - includes any validation warnings
+ */
+export interface LoadPreferencesResult {
+  preferences: UserPreferences;
+  warnings: string[];
+}
+
+/**
+ * Validate a timeline tab value.
+ * Returns the valid tab or undefined if invalid.
+ */
+function validateTimelineTab(value: unknown): TimelineTab | undefined {
+  if (typeof value === "string") {
+    if (VALID_TIMELINE_TABS.includes(value as TimelineTab)) {
+      return value as TimelineTab;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Load user preferences from ~/.config/xfeed/preferences.toml
+ *
+ * Returns default preferences if:
+ * - File doesn't exist (no warnings)
+ * - File is empty (no warnings)
+ * - File has read errors (warning logged)
+ *
+ * Individual invalid values fall back to defaults with warnings.
+ */
+export function loadPreferences(): LoadPreferencesResult {
+  const warnings: string[] = [];
+  const preferences: UserPreferences = structuredClone(DEFAULT_PREFERENCES);
+
+  // Return defaults if file doesn't exist (common case, no warning)
+  if (!existsSync(PREFERENCES_PATH)) {
+    return { preferences, warnings };
+  }
+
+  let content: string;
+  try {
+    content = readFileSync(PREFERENCES_PATH, "utf-8");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    warnings.push(`Could not read preferences file: ${message}`);
+    return { preferences, warnings };
+  }
+
+  // Empty file is valid - just use defaults
+  if (content.trim() === "") {
+    return { preferences, warnings };
+  }
+
+  // Parse TOML
+  const parsed = parseToml(content);
+
+  // Validate [timeline] section
+  const timeline = parsed["timeline"];
+  if (timeline) {
+    // Validate timeline.default_tab
+    if ("default_tab" in timeline) {
+      const validTab = validateTimelineTab(timeline["default_tab"]);
+      if (validTab) {
+        preferences.timeline.default_tab = validTab;
+      } else {
+        warnings.push(
+          `Invalid timeline.default_tab: "${timeline["default_tab"]}". ` +
+            `Must be one of: ${VALID_TIMELINE_TABS.join(", ")}. ` +
+            `Using default: "${DEFAULT_PREFERENCES.timeline.default_tab}"`
+        );
+      }
+    }
+  }
+
+  return { preferences, warnings };
+}
+
+/**
+ * Get the preferences file path (for display purposes).
+ */
+export function getPreferencesPath(): string {
+  return PREFERENCES_PATH;
+}

--- a/src/config/toml.test.ts
+++ b/src/config/toml.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "bun:test";
+
+import { parseToml } from "./toml";
+
+describe("parseToml", () => {
+  it("parses section headers", () => {
+    const result = parseToml("[timeline]\n[theme]");
+
+    expect(result).toEqual({
+      timeline: {},
+      theme: {},
+    });
+  });
+
+  it("parses key-value pairs with double quotes", () => {
+    const result = parseToml('[timeline]\ndefault_tab = "following"');
+
+    expect(result).toEqual({
+      timeline: { default_tab: "following" },
+    });
+  });
+
+  it("parses key-value pairs with single quotes", () => {
+    const result = parseToml("[timeline]\ndefault_tab = 'for_you'");
+
+    expect(result).toEqual({
+      timeline: { default_tab: "for_you" },
+    });
+  });
+
+  it("ignores empty lines", () => {
+    const result = parseToml('[timeline]\n\ndefault_tab = "test"\n\n');
+
+    expect(result).toEqual({
+      timeline: { default_tab: "test" },
+    });
+  });
+
+  it("ignores comment lines", () => {
+    const result = parseToml(
+      '# This is a comment\n[timeline]\n# Another comment\ndefault_tab = "test"'
+    );
+
+    expect(result).toEqual({
+      timeline: { default_tab: "test" },
+    });
+  });
+
+  it("handles multiple sections", () => {
+    const result = parseToml(
+      '[timeline]\ndefault_tab = "following"\n\n[theme]\npreset = "dark"'
+    );
+
+    expect(result).toEqual({
+      timeline: { default_tab: "following" },
+      theme: { preset: "dark" },
+    });
+  });
+
+  it("handles multiple keys in a section", () => {
+    const result = parseToml(
+      '[colors]\naccent = "#1DA1F2"\nbackground = "#000000"'
+    );
+
+    expect(result).toEqual({
+      colors: {
+        accent: "#1DA1F2",
+        background: "#000000",
+      },
+    });
+  });
+
+  it("ignores key-value pairs before any section", () => {
+    const result = parseToml('orphan_key = "value"\n[timeline]\nok = "yes"');
+
+    expect(result).toEqual({
+      timeline: { ok: "yes" },
+    });
+  });
+
+  it("parses unquoted alphanumeric values", () => {
+    const result = parseToml("[timeline]\ndefault_tab = following");
+
+    expect(result).toEqual({
+      timeline: { default_tab: "following" },
+    });
+  });
+
+  it("parses unquoted values with underscores", () => {
+    const result = parseToml("[timeline]\ndefault_tab = for_you");
+
+    expect(result).toEqual({
+      timeline: { default_tab: "for_you" },
+    });
+  });
+
+  it("ignores malformed lines", () => {
+    const result = parseToml(
+      '[timeline]\ndefault_tab = "ok"\nthis is not valid'
+    );
+
+    expect(result).toEqual({
+      timeline: { default_tab: "ok" },
+    });
+  });
+
+  it("returns empty object for empty input", () => {
+    expect(parseToml("")).toEqual({});
+  });
+
+  it("returns empty object for comments-only input", () => {
+    expect(parseToml("# just a comment\n# another one")).toEqual({});
+  });
+
+  it("handles empty string values", () => {
+    const result = parseToml('[timeline]\nempty = ""');
+
+    expect(result).toEqual({
+      timeline: { empty: "" },
+    });
+  });
+
+  it("handles values with spaces", () => {
+    const result = parseToml('[section]\nkey = "hello world"');
+
+    expect(result).toEqual({
+      section: { key: "hello world" },
+    });
+  });
+
+  it("handles keys with underscores and numbers", () => {
+    const result = parseToml('[section]\nmy_key_2 = "value"');
+
+    expect(result).toEqual({
+      section: { my_key_2: "value" },
+    });
+  });
+
+  it("handles whitespace around equals sign", () => {
+    const result = parseToml('[section]\nkey   =   "value"');
+
+    expect(result).toEqual({
+      section: { key: "value" },
+    });
+  });
+});

--- a/src/config/toml.ts
+++ b/src/config/toml.ts
@@ -1,0 +1,77 @@
+/**
+ * Minimal TOML parser for simple config files.
+ *
+ * Supports:
+ * - Section headers: [section_name]
+ * - String values: key = "value" or key = 'value'
+ * - Unquoted values: key = value (for simple alphanumeric values)
+ * - Comments: # comment
+ * - Empty lines (ignored)
+ *
+ * Does NOT support:
+ * - Nested sections, arrays, inline tables
+ * - Numbers, booleans (all values are strings)
+ * - Multiline strings, escape sequences
+ */
+
+export type TomlData = Record<string, Record<string, string>>;
+
+/**
+ * Parse a simple TOML config string into a nested object.
+ *
+ * @param content - TOML file content
+ * @returns Parsed data as { section: { key: value } }
+ *
+ * @example
+ * parseToml('[timeline]\ndefault_tab = "following"')
+ * // => { timeline: { default_tab: "following" } }
+ *
+ * @example
+ * parseToml('[timeline]\ndefault_tab = following')
+ * // => { timeline: { default_tab: "following" } }
+ */
+export function parseToml(content: string): TomlData {
+  const result: TomlData = {};
+  let currentSection = "";
+
+  for (const rawLine of content.split("\n")) {
+    const line = rawLine.trim();
+
+    // Skip empty lines and comments
+    if (line === "" || line.startsWith("#")) {
+      continue;
+    }
+
+    // Section header: [section_name]
+    const sectionMatch = line.match(/^\[([a-zA-Z_][a-zA-Z0-9_]*)\]$/);
+    if (sectionMatch?.[1]) {
+      currentSection = sectionMatch[1];
+      result[currentSection] ??= {};
+      continue;
+    }
+
+    // Key-value with quoted value: key = "value" or key = 'value'
+    const quotedMatch = line.match(
+      /^([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*["'](.*)["']$/
+    );
+    const section = result[currentSection];
+    if (quotedMatch?.[1] && quotedMatch[2] !== undefined && section) {
+      section[quotedMatch[1]] = quotedMatch[2];
+      continue;
+    }
+
+    // Key-value with unquoted value: key = value (alphanumeric/underscore only)
+    const unquotedMatch = line.match(
+      /^([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*([a-zA-Z_][a-zA-Z0-9_]*)$/
+    );
+    if (unquotedMatch?.[1] && unquotedMatch[2] && section) {
+      section[unquotedMatch[1]] = unquotedMatch[2];
+      continue;
+    }
+
+    // Lines that don't match any pattern are silently ignored
+    // This provides forward compatibility with future TOML features
+  }
+
+  return result;
+}

--- a/src/contexts/PreferencesContext.tsx
+++ b/src/contexts/PreferencesContext.tsx
@@ -1,0 +1,72 @@
+/**
+ * PreferencesContext - Provides user preferences to the component tree
+ *
+ * Preferences are loaded once at startup from ~/.config/xfeed/preferences.toml
+ * and remain immutable during the session. Restart xfeed to pick up changes.
+ *
+ * Usage:
+ *   const { preferences } = usePreferences();
+ *   const defaultTab = preferences.timeline.default_tab;
+ */
+
+import { createContext, useContext, type ReactNode } from "react";
+
+import type { UserPreferences } from "@/config/preferences-types";
+
+// ============================================================================
+// Context Definition
+// ============================================================================
+
+/** Context value exposed to consumers */
+export interface PreferencesContextValue {
+  /** User preferences (loaded at startup, immutable during session) */
+  preferences: UserPreferences;
+}
+
+const PreferencesContext = createContext<PreferencesContextValue | null>(null);
+
+// ============================================================================
+// PreferencesProvider Component
+// ============================================================================
+
+interface PreferencesProviderProps {
+  preferences: UserPreferences;
+  children: ReactNode;
+}
+
+/**
+ * Provider that makes user preferences available to the component tree.
+ *
+ * Preferences are loaded once at startup in index.tsx and passed here.
+ * They are immutable during the session (restart to pick up changes).
+ */
+export function PreferencesProvider({
+  preferences,
+  children,
+}: PreferencesProviderProps) {
+  const contextValue: PreferencesContextValue = {
+    preferences,
+  };
+
+  return (
+    <PreferencesContext.Provider value={contextValue}>
+      {children}
+    </PreferencesContext.Provider>
+  );
+}
+
+// ============================================================================
+// usePreferences Hook
+// ============================================================================
+
+/**
+ * Hook to access user preferences.
+ * @throws Error if used outside PreferencesProvider
+ */
+export function usePreferences(): PreferencesContextValue {
+  const context = useContext(PreferencesContext);
+  if (!context) {
+    throw new Error("usePreferences must be used within a PreferencesProvider");
+  }
+  return context;
+}

--- a/src/experiments/TimelineScreenExperimental.tsx
+++ b/src/experiments/TimelineScreenExperimental.tsx
@@ -15,6 +15,7 @@ import type { TweetActionState } from "@/hooks/useActions";
 
 import { ErrorBanner } from "@/components/ErrorBanner";
 import { PostList } from "@/components/PostList";
+import { usePreferences } from "@/contexts/PreferencesContext";
 import { colors } from "@/lib/colors";
 
 import { type TimelineTab, useTimelineQuery } from "./use-timeline-query";
@@ -107,6 +108,8 @@ export function TimelineScreenExperimental({
   getActionState,
   initActionState,
 }: TimelineScreenExperimentalProps) {
+  const { preferences } = usePreferences();
+
   const {
     tab,
     setTab,
@@ -121,6 +124,7 @@ export function TimelineScreenExperimental({
     isRefetching,
   } = useTimelineQuery({
     client,
+    initialTab: preferences.timeline.default_tab,
   });
 
   // Report post count to parent

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -40,7 +40,9 @@ import {
   loadConfig,
   updateConfig,
 } from "@/config/loader";
+import { getPreferencesPath, loadPreferences } from "@/config/preferences";
 import { ModalProvider } from "@/contexts/ModalContext";
+import { PreferencesProvider } from "@/contexts/PreferencesContext";
 
 const cli = cac("xfeed");
 
@@ -283,6 +285,18 @@ cli
         }
       }
 
+      // Load user preferences
+      const { preferences, warnings: prefWarnings } = loadPreferences();
+
+      // Show preference warnings if any
+      if (prefWarnings.length > 0) {
+        console.warn("Preference warnings:");
+        for (const warning of prefWarnings) {
+          console.warn(`  - ${warning}`);
+        }
+        console.warn(`  Config file: ${getPreferencesPath()}\n`);
+      }
+
       // Clear screen before launching TUI (removes any auth flow output)
       process.stdout.write("\x1b[2J\x1b[H");
 
@@ -292,9 +306,11 @@ cli
       });
 
       createRoot(renderer).render(
-        <ModalProvider>
-          <App client={authResult.client} user={authResult.user} />
-        </ModalProvider>
+        <PreferencesProvider preferences={preferences}>
+          <ModalProvider>
+            <App client={authResult.client} user={authResult.user} />
+          </ModalProvider>
+        </PreferencesProvider>
       );
     }
   );


### PR DESCRIPTION
## Summary
Implements user preferences infrastructure with TOML configuration at `~/.config/xfeed/preferences.toml`. First preference: `timeline.default_tab` (For You / Following). Includes minimal inline TOML parser (~40 lines, zero dependencies), preferences loader with validation and graceful fallbacks, and React Context for app-wide access.

## Architecture
- `src/config/toml.ts` - TOML parser (supports quoted and unquoted alphanumeric values, comments, sections)
- `src/config/preferences.ts` - Loader with validation, warns on invalid values
- `src/contexts/PreferencesContext.tsx` - React Context for accessing preferences throughout the app
- Integration in `src/index.tsx` - Loads preferences at startup before launching TUI

## Testing
- 26 new tests added (TOML parser + preferences loader)
- All 259 tests passing
- Tests use isolated batches to prevent mock pollution
- TypeScript strict mode, linting passes

## Preparation for Future Work
Architecture supports adding theme customization and keybindings without changes to core infrastructure. See #180 for planned Settings screen UI.

Fixes #28