### PR TITLE
feat(bookmarks): Add bookmark folder mutation operations (#170)

### DIFF
--- a/src/api/query-ids.ts
+++ b/src/api/query-ids.ts
@@ -41,6 +41,9 @@ export const FALLBACK_QUERY_IDS = {
   BookmarkFoldersSlice: "i78YDd0Tza-dV4SYs58kRg",
   bookmarkTweetToFolder: "4KHZvvNbHNf07bsgnL9gWA",
   NotificationsTimeline: "Ev6UMJRROInk_RMH2oVbBg",
+  createBookmarkFolder: "6Xxqpq8TM_CREYiuof_h5w",
+  DeleteBookmarkFolder: "2UTTsO-6zs93XqlEUZPsSg",
+  EditBookmarkFolder: "a6kPp1cS1Dgbsjhapz1PNw",
 } as const;
 
 /**

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -396,7 +396,10 @@ export type OperationName =
   | "Likes"
   | "BookmarkFoldersSlice"
   | "bookmarkTweetToFolder"
-  | "NotificationsTimeline";
+  | "NotificationsTimeline"
+  | "createBookmarkFolder"
+  | "DeleteBookmarkFolder"
+  | "EditBookmarkFolder";
 
 /**
  * Result of an action mutation (like, bookmark, etc.)
@@ -420,6 +423,13 @@ export interface BookmarkFolder {
  */
 export type BookmarkFoldersResult =
   | { success: true; folders: BookmarkFolder[] }
+  | { success: false; error: string };
+
+/**
+ * Result of a bookmark folder mutation (create, edit)
+ */
+export type BookmarkFolderMutationResult =
+  | { success: true; folder: BookmarkFolder }
   | { success: false; error: string };
 
 /**

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -362,6 +362,69 @@ function AppContent({ client, user }: AppProps) {
     });
   }, [client, selectedBookmarkFolder, openModal, closeModal]);
 
+  // Create new bookmark folder
+  const handleCreateBookmarkFolder = useCallback(() => {
+    openModal("folder-name-input", {
+      mode: "create",
+      onSubmit: async (name: string) => {
+        const result = await client.createBookmarkFolder(name);
+        if (result.success) {
+          setActionMessage(`Created folder "${name}"`);
+          closeModal();
+        } else {
+          throw new Error(result.error);
+        }
+      },
+      onClose: closeModal,
+    });
+  }, [client, openModal, closeModal]);
+
+  // Edit current bookmark folder
+  const handleEditBookmarkFolder = useCallback(() => {
+    if (!selectedBookmarkFolder) return;
+
+    openModal("folder-name-input", {
+      mode: "edit",
+      initialName: selectedBookmarkFolder.name,
+      onSubmit: async (name: string) => {
+        const result = await client.editBookmarkFolder(
+          selectedBookmarkFolder.id,
+          name
+        );
+        if (result.success) {
+          setSelectedBookmarkFolder(result.folder);
+          setActionMessage(`Renamed folder to "${name}"`);
+          closeModal();
+        } else {
+          throw new Error(result.error);
+        }
+      },
+      onClose: closeModal,
+    });
+  }, [client, selectedBookmarkFolder, openModal, closeModal]);
+
+  // Delete current bookmark folder
+  const handleDeleteBookmarkFolder = useCallback(() => {
+    if (!selectedBookmarkFolder) return;
+
+    openModal("delete-folder-confirm", {
+      folderName: selectedBookmarkFolder.name,
+      onConfirm: async () => {
+        const result = await client.deleteBookmarkFolder(
+          selectedBookmarkFolder.id
+        );
+        if (result.success) {
+          setActionMessage(`Deleted folder "${selectedBookmarkFolder.name}"`);
+          setSelectedBookmarkFolder(null);
+          closeModal();
+        } else {
+          throw new Error(result.error);
+        }
+      },
+      onCancel: closeModal,
+    });
+  }, [client, selectedBookmarkFolder, openModal, closeModal]);
+
   // Handle notification select - navigate to tweet detail or profile based on type
   const handleNotificationSelect = useCallback(
     (notification: NotificationData) => {
@@ -654,6 +717,9 @@ function AppContent({ client, user }: AppProps) {
             onBookmark={toggleBookmark}
             getActionState={getState}
             initActionState={initState}
+            onCreateFolder={handleCreateBookmarkFolder}
+            onEditFolder={handleEditBookmarkFolder}
+            onDeleteFolder={handleDeleteBookmarkFolder}
           />
         </box>
 

--- a/src/contexts/ModalContext.tsx
+++ b/src/contexts/ModalContext.tsx
@@ -22,7 +22,9 @@ import type { XClient } from "@/api/client";
 import type { BookmarkFolder, TweetData } from "@/api/types";
 
 import { BookmarkFolderSelector } from "@/modals/BookmarkFolderSelector";
+import { DeleteFolderConfirmModal } from "@/modals/DeleteFolderConfirmModal";
 import { ExitConfirmationModal } from "@/modals/ExitConfirmationModal";
+import { FolderNameInputModal } from "@/modals/FolderNameInputModal";
 import { FolderPicker } from "@/modals/FolderPicker";
 import { SessionExpiredModal } from "@/modals/SessionExpiredModal";
 
@@ -35,7 +37,9 @@ export type ModalType =
   | "folder-picker"
   | "bookmark-folder-selector"
   | "exit-confirmation"
-  | "session-expired";
+  | "session-expired"
+  | "folder-name-input"
+  | "delete-folder-confirm";
 
 /** Props for FolderPicker modal */
 export interface FolderPickerModalProps {
@@ -63,12 +67,29 @@ export interface ExitConfirmationModalProps {
 /** Props for SessionExpiredModal (terminal - no props needed) */
 export interface SessionExpiredModalProps {}
 
+/** Props for FolderNameInputModal */
+export interface FolderNameInputModalProps {
+  mode: "create" | "edit";
+  initialName?: string;
+  onSubmit: (name: string) => Promise<void>;
+  onClose: () => void;
+}
+
+/** Props for DeleteFolderConfirmModal */
+export interface DeleteFolderConfirmModalProps {
+  folderName: string;
+  onConfirm: () => Promise<void>;
+  onCancel: () => void;
+}
+
 /** Map of modal type to its props type for type inference */
 export interface ModalPropsMap {
   "folder-picker": FolderPickerModalProps;
   "bookmark-folder-selector": BookmarkFolderSelectorModalProps;
   "exit-confirmation": ExitConfirmationModalProps;
   "session-expired": SessionExpiredModalProps;
+  "folder-name-input": FolderNameInputModalProps;
+  "delete-folder-confirm": DeleteFolderConfirmModalProps;
 }
 
 /** Discriminated union of all possible modal states */
@@ -80,6 +101,8 @@ export type ModalState =
     }
   | { type: "exit-confirmation"; props: ExitConfirmationModalProps }
   | { type: "session-expired"; props: SessionExpiredModalProps }
+  | { type: "folder-name-input"; props: FolderNameInputModalProps }
+  | { type: "delete-folder-confirm"; props: DeleteFolderConfirmModalProps }
   | null;
 
 // ============================================================================
@@ -159,6 +182,20 @@ function ModalRenderer({ activeModal }: ModalRendererProps) {
     case "session-expired":
       // SessionExpiredModal includes its own absolute positioning
       return <SessionExpiredModal />;
+
+    case "folder-name-input":
+      return (
+        <ModalWrapper>
+          <FolderNameInputModal {...activeModal.props} focused={true} />
+        </ModalWrapper>
+      );
+
+    case "delete-folder-confirm":
+      return (
+        <ModalWrapper>
+          <DeleteFolderConfirmModal {...activeModal.props} focused={true} />
+        </ModalWrapper>
+      );
   }
 }
 

--- a/src/modals/DeleteFolderConfirmModal.tsx
+++ b/src/modals/DeleteFolderConfirmModal.tsx
@@ -1,0 +1,134 @@
+/**
+ * DeleteFolderConfirmModal - Confirmation modal for deleting a bookmark folder
+ *
+ * Shows folder name and confirm/cancel options.
+ * - Enter/y to confirm
+ * - Esc/n to cancel
+ */
+
+import { useKeyboard } from "@opentui/react";
+import { useState } from "react";
+
+import { colors } from "@/lib/colors";
+
+interface DeleteFolderConfirmModalProps {
+  /** Name of the folder being deleted */
+  folderName: string;
+  /** Called when user confirms deletion */
+  onConfirm: () => Promise<void>;
+  /** Called when user cancels */
+  onCancel: () => void;
+  /** Whether the modal is focused */
+  focused?: boolean;
+}
+
+export function DeleteFolderConfirmModal({
+  folderName,
+  onConfirm,
+  onCancel,
+  focused = true,
+}: DeleteFolderConfirmModalProps) {
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleConfirm = async () => {
+    if (isDeleting) return;
+
+    setIsDeleting(true);
+    setError(null);
+
+    try {
+      await onConfirm();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete folder");
+      setIsDeleting(false);
+    }
+  };
+
+  useKeyboard((key) => {
+    if (!focused || isDeleting) return;
+
+    if (key.name === "y" || key.name === "return") {
+      handleConfirm();
+      return;
+    }
+
+    if (key.name === "n" || key.name === "escape") {
+      onCancel();
+    }
+  });
+
+  return (
+    <box
+      style={{
+        flexDirection: "column",
+        height: "100%",
+        justifyContent: "center",
+        alignItems: "center",
+      }}
+      backgroundColor="#000000"
+      opacity={0.8}
+    >
+      <box
+        style={{
+          flexDirection: "column",
+          padding: 2,
+          minWidth: 35,
+          maxWidth: 50,
+        }}
+      >
+        <box
+          style={{
+            borderStyle: "rounded",
+            borderColor: error ? colors.error : colors.warning,
+            padding: 1,
+            flexDirection: "column",
+          }}
+          backgroundColor="#000000"
+        >
+          {/* Title */}
+          <box style={{ paddingBottom: 1 }}>
+            <text fg={colors.warning}>
+              <b>Delete folder?</b>
+            </text>
+          </box>
+
+          {/* Folder name */}
+          <box style={{ paddingBottom: 1 }}>
+            <text fg={colors.muted}>Folder: </text>
+            <text fg={colors.primary}>"{folderName}"</text>
+          </box>
+
+          {/* Warning */}
+          <box style={{ paddingBottom: 1 }}>
+            <text fg={colors.dim}>
+              Bookmarks will be moved to All Bookmarks.
+            </text>
+          </box>
+
+          {/* Error message */}
+          {error ? (
+            <box style={{ paddingBottom: 1 }}>
+              <text fg={colors.error}>{error}</text>
+            </box>
+          ) : null}
+
+          {/* Loading state */}
+          {isDeleting ? (
+            <box style={{ paddingBottom: 1 }}>
+              <text fg={colors.muted}>Deleting...</text>
+            </box>
+          ) : null}
+
+          {/* Footer hints */}
+          <box style={{ flexDirection: "row" }}>
+            <text fg={colors.dim}>y/Enter</text>
+            <text fg="#444444"> delete </text>
+            <text fg={colors.dim}>n/Esc</text>
+            <text fg="#444444"> cancel</text>
+          </box>
+        </box>
+      </box>
+    </box>
+  );
+}

--- a/src/modals/FolderNameInputModal.tsx
+++ b/src/modals/FolderNameInputModal.tsx
@@ -1,0 +1,185 @@
+/**
+ * FolderNameInputModal - Modal for creating or editing a bookmark folder name
+ *
+ * Uses OpenTUI's <input> intrinsic for text entry with:
+ * - Max 25 character limit
+ * - Enter to submit, Esc to cancel
+ * - Loading state during submission
+ * - Error display on failure
+ */
+
+import { useKeyboard } from "@opentui/react";
+import { useEffect, useState } from "react";
+
+import { colors } from "@/lib/colors";
+
+const MAX_FOLDER_NAME_LENGTH = 25;
+
+interface FolderNameInputModalProps {
+  /** Whether creating a new folder or editing existing */
+  mode: "create" | "edit";
+  /** Initial name value (for edit mode) */
+  initialName?: string;
+  /** Called when user submits a valid name */
+  onSubmit: (name: string) => Promise<void>;
+  /** Called when user cancels (Esc) */
+  onClose: () => void;
+  /** Whether the modal is focused */
+  focused?: boolean;
+}
+
+export function FolderNameInputModal({
+  mode,
+  initialName = "",
+  onSubmit,
+  onClose,
+  focused = true,
+}: FolderNameInputModalProps) {
+  const [value, setValue] = useState(initialName);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset state when modal opens
+  useEffect(() => {
+    setValue(initialName);
+    setError(null);
+    setIsSubmitting(false);
+  }, [initialName]);
+
+  const handleSubmit = async () => {
+    const trimmed = value.trim();
+
+    if (!trimmed) {
+      setError("Folder name cannot be empty");
+      return;
+    }
+
+    if (trimmed.length > MAX_FOLDER_NAME_LENGTH) {
+      setError(`Name must be ${MAX_FOLDER_NAME_LENGTH} characters or less`);
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      await onSubmit(trimmed);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save folder");
+      setIsSubmitting(false);
+    }
+  };
+
+  useKeyboard((key) => {
+    if (!focused || isSubmitting) return;
+
+    if (key.name === "escape") {
+      onClose();
+    }
+  });
+
+  const title = mode === "create" ? "Create folder" : "Rename folder";
+  const buttonText = mode === "create" ? "Create" : "Save";
+
+  return (
+    <box
+      style={{
+        flexDirection: "column",
+        height: "100%",
+        justifyContent: "center",
+        alignItems: "center",
+      }}
+      backgroundColor="#000000"
+      opacity={0.8}
+    >
+      <box
+        style={{
+          flexDirection: "column",
+          padding: 2,
+          minWidth: 35,
+          maxWidth: 50,
+        }}
+      >
+        <box
+          style={{
+            borderStyle: "rounded",
+            borderColor: error ? colors.error : "#444444",
+            padding: 1,
+            flexDirection: "column",
+          }}
+          backgroundColor="#000000"
+        >
+          {/* Title */}
+          <box style={{ paddingBottom: 1 }}>
+            <text fg={colors.primary}>
+              <b>{title}</b>
+            </text>
+          </box>
+
+          {/* Input field */}
+          <box
+            style={{
+              flexDirection: "row",
+              paddingBottom: 1,
+            }}
+          >
+            <input
+              value={value}
+              placeholder="Enter folder name..."
+              maxLength={MAX_FOLDER_NAME_LENGTH}
+              focused={focused && !isSubmitting}
+              onInput={(newValue: string) => {
+                setValue(newValue);
+                if (error) setError(null);
+              }}
+              onSubmit={() => {
+                handleSubmit();
+              }}
+              width={30}
+              height={1}
+              backgroundColor="#1a1a1a"
+              textColor="#ffffff"
+              placeholderColor="#666666"
+              cursorColor={colors.primary}
+            />
+          </box>
+
+          {/* Character count */}
+          <box style={{ paddingBottom: 1 }}>
+            <text
+              fg={
+                value.length > MAX_FOLDER_NAME_LENGTH
+                  ? colors.error
+                  : colors.dim
+              }
+            >
+              {value.length}/{MAX_FOLDER_NAME_LENGTH}
+            </text>
+          </box>
+
+          {/* Error message */}
+          {error ? (
+            <box style={{ paddingBottom: 1 }}>
+              <text fg={colors.error}>{error}</text>
+            </box>
+          ) : null}
+
+          {/* Loading state */}
+          {isSubmitting ? (
+            <box style={{ paddingBottom: 1 }}>
+              <text fg={colors.muted}>Saving...</text>
+            </box>
+          ) : null}
+
+          {/* Footer hints */}
+          <box style={{ flexDirection: "row" }}>
+            <text fg={colors.dim}>Enter</text>
+            <text fg="#444444"> {buttonText.toLowerCase()} </text>
+            <text fg={colors.dim}>Esc</text>
+            <text fg="#444444"> cancel</text>
+          </box>
+        </box>
+      </box>
+    </box>
+  );
+}

--- a/src/modals/index.ts
+++ b/src/modals/index.ts
@@ -1,4 +1,6 @@
 export { BookmarkFolderSelector } from "./BookmarkFolderSelector";
+export { DeleteFolderConfirmModal } from "./DeleteFolderConfirmModal";
 export { ExitConfirmationModal } from "./ExitConfirmationModal";
+export { FolderNameInputModal } from "./FolderNameInputModal";
 export { FolderPicker } from "./FolderPicker";
 export { SessionExpiredModal } from "./SessionExpiredModal";


### PR DESCRIPTION
Fixes #170

## Summary
Add create, edit, and delete mutations for bookmark folders with full UI integration.

## Implementation
- Three new XClient methods with 404 retry logic for folder mutations
- FolderNameInputModal for create/edit with 25-character limit
- DeleteFolderConfirmModal for deletion confirmation
- Keyboard shortcuts: c (create), e (edit), D (delete) in BookmarksScreen
- Full modal registration in ModalContext with type-safe discriminated unions

## Test Plan
✓ All endpoints tested with user tokens (create, edit, delete)
✓ TypeScript compilation passes
✓ All linting checks pass
✓ 259 tests passing (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)