### PR TITLE
fix(screens): Prevent header/banner bleeding between screens (#178)

### DIFF
--- a/src/experiments/TimelineScreenExperimental.tsx
+++ b/src/experiments/TimelineScreenExperimental.tsx
@@ -199,7 +199,7 @@ export function TimelineScreenExperimental({
       {focused && <TabBar activeTab={tab} isRefetching={isRefetching} />}
 
       {/* Refresh banner */}
-      {showRefreshBanner && <RefreshBanner />}
+      {focused && showRefreshBanner && <RefreshBanner />}
 
       <PostList
         posts={posts}

--- a/src/screens/BookmarksScreen.tsx
+++ b/src/screens/BookmarksScreen.tsx
@@ -146,7 +146,9 @@ export function BookmarksScreen({
   if (isLoading) {
     return (
       <box style={{ flexDirection: "column", height: "100%" }}>
-        <ScreenHeader folderName={folderName} inFolder={inFolder} />
+        {focused && (
+          <ScreenHeader folderName={folderName} inFolder={inFolder} />
+        )}
         <box style={{ padding: 2, flexGrow: 1 }}>
           <text fg={colors.muted}>Loading bookmarks...</text>
         </box>
@@ -157,7 +159,9 @@ export function BookmarksScreen({
   if (error) {
     return (
       <box style={{ flexDirection: "column", height: "100%" }}>
-        <ScreenHeader folderName={folderName} inFolder={inFolder} />
+        {focused && (
+          <ScreenHeader folderName={folderName} inFolder={inFolder} />
+        )}
         <ErrorBanner error={error} onRetry={refresh} retryDisabled={false} />
       </box>
     );
@@ -166,7 +170,9 @@ export function BookmarksScreen({
   if (posts.length === 0) {
     return (
       <box style={{ flexDirection: "column", height: "100%" }}>
-        <ScreenHeader folderName={folderName} inFolder={inFolder} />
+        {focused && (
+          <ScreenHeader folderName={folderName} inFolder={inFolder} />
+        )}
         <box style={{ padding: 2, flexGrow: 1 }}>
           <text fg={colors.muted}>
             {selectedFolder
@@ -180,7 +186,7 @@ export function BookmarksScreen({
 
   return (
     <box style={{ flexDirection: "column", height: "100%" }}>
-      <ScreenHeader folderName={folderName} inFolder={inFolder} />
+      {focused && <ScreenHeader folderName={folderName} inFolder={inFolder} />}
       <PostList
         posts={posts}
         focused={focused}

--- a/src/screens/NotificationsScreen.tsx
+++ b/src/screens/NotificationsScreen.tsx
@@ -123,7 +123,7 @@ export function NotificationsScreen({
   if (isLoading) {
     return (
       <box style={{ flexDirection: "column", height: "100%" }}>
-        <ScreenHeader unreadCount={0} isRefetching={false} />
+        {focused && <ScreenHeader unreadCount={0} isRefetching={false} />}
         <box style={{ padding: 2, flexGrow: 1 }}>
           <text fg={colors.muted}>Loading notifications...</text>
         </box>
@@ -134,7 +134,9 @@ export function NotificationsScreen({
   if (error) {
     return (
       <box style={{ flexDirection: "column", height: "100%" }}>
-        <ScreenHeader unreadCount={0} isRefetching={isRefetching} />
+        {focused && (
+          <ScreenHeader unreadCount={0} isRefetching={isRefetching} />
+        )}
         <ErrorBanner error={error} onRetry={refresh} retryDisabled={false} />
       </box>
     );
@@ -143,7 +145,9 @@ export function NotificationsScreen({
   if (notifications.length === 0) {
     return (
       <box style={{ flexDirection: "column", height: "100%" }}>
-        <ScreenHeader unreadCount={0} isRefetching={isRefetching} />
+        {focused && (
+          <ScreenHeader unreadCount={0} isRefetching={isRefetching} />
+        )}
         <box style={{ padding: 2, flexGrow: 1 }}>
           <text fg={colors.muted}>
             No notifications yet. Press r to refresh.
@@ -155,8 +159,10 @@ export function NotificationsScreen({
 
   return (
     <box style={{ flexDirection: "column", height: "100%" }}>
-      <ScreenHeader unreadCount={unreadCount} isRefetching={isRefetching} />
-      {newNotificationsCount > 0 && (
+      {focused && (
+        <ScreenHeader unreadCount={unreadCount} isRefetching={isRefetching} />
+      )}
+      {focused && newNotificationsCount > 0 && (
         <NewNotificationsBanner count={newNotificationsCount} />
       )}
       <NotificationList


### PR DESCRIPTION
## Summary

Fix header and banner components bleeding between main screens when navigating. All main screens are always mounted but hidden with `height: 0`, causing their headers/banners to render over active screens.

## Changes

Gate screen headers and banners with the `focused` prop:
- TimelineScreen: RefreshBanner
- BookmarksScreen: ScreenHeader
- NotificationsScreen: ScreenHeader and NewNotificationsBanner

Consistent with existing TabBar guard in TimelineScreen.

## Test Plan

- Navigate between Timeline/Bookmarks/Notifications tabs
- Verify headers/banners only appear on active screen
- No visual corruption or text overlap between screens