### PR TITLE
fix(bookmarks): Reduce visible folders to 5 to prevent row bleeding

### DIFF
--- a/src/modals/BookmarkFolderSelector.tsx
+++ b/src/modals/BookmarkFolderSelector.tsx
@@ -28,7 +28,7 @@ interface BookmarkFolderSelectorProps {
   focused?: boolean;
 }
 
-const MAX_VISIBLE_ITEMS = 10;
+const MAX_VISIBLE_ITEMS = 5;
 
 export function BookmarkFolderSelector({
   client,

--- a/src/modals/FolderPicker.tsx
+++ b/src/modals/FolderPicker.tsx
@@ -27,7 +27,7 @@ interface FolderPickerProps {
   focused?: boolean;
 }
 
-const MAX_VISIBLE_FOLDERS = 10;
+const MAX_VISIBLE_FOLDERS = 5;
 
 export function FolderPicker({
   client,


### PR DESCRIPTION
## Summary

Reduces the number of visible folder items in bookmark folder modals from 10 to 5 to prevent rows from visually bleeding into each other.

## Changes

- `BookmarkFolderSelector.tsx`: Changed `MAX_VISIBLE_ITEMS` from 10 to 5
- `FolderPicker.tsx`: Changed `MAX_VISIBLE_FOLDERS` from 10 to 5

## Testing

- All 259 tests passing
- TypeScript type checking passed
- Linting checks passed

Fixes #190