### PR TITLE
fix: Replace confusing '...' with [Show more] indicator

### DIFF
--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -5,7 +5,12 @@
 import type { TweetData } from "@/api/types";
 
 import { colors } from "@/lib/colors";
-import { formatCount, formatRelativeTime, truncateText } from "@/lib/format";
+import {
+  formatCount,
+  formatRelativeTime,
+  isTruncated,
+  truncateText,
+} from "@/lib/format";
 
 import { QuotedPostCard } from "./QuotedPostCard";
 import { ReplyPreviewCard } from "./ReplyPreviewCard";
@@ -66,6 +71,7 @@ export function PostCard({
     ? stripLeadingMention(post.text, parentAuthorUsername)
     : post.text;
   const displayText = truncateText(textToDisplay, MAX_TEXT_LINES);
+  const showShowMore = isTruncated(textToDisplay, MAX_TEXT_LINES);
   const timeAgo = formatRelativeTime(post.createdAt);
   const hasMedia = post.media && post.media.length > 0;
 
@@ -92,10 +98,11 @@ export function PostCard({
       </box>
 
       {/* Post text */}
-      <box style={{ marginTop: 1, paddingLeft: 2 }}>
+      <box style={{ marginTop: 1, paddingLeft: 2, flexDirection: "column" }}>
         <text fg="#ffffff" selectable selectionBg="#264F78">
           {displayText}
         </text>
+        {showShowMore && <text fg={colors.primary}>[Show more]</text>}
       </box>
 
       {/* Quoted tweet (if present) */}

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -24,7 +24,8 @@ export function formatRelativeTime(dateString?: string): string {
 }
 
 /**
- * Truncate text to a maximum number of lines
+ * Truncate text to a maximum number of lines.
+ * Does NOT add "..." - caller should show a separate [Show more] indicator.
  */
 export function truncateText(
   text: string,
@@ -33,19 +34,43 @@ export function truncateText(
 ): string {
   const lines = text.split("\n").slice(0, maxLines);
   const truncated = lines.map((line) =>
-    line.length > maxCharsPerLine
-      ? `${line.slice(0, maxCharsPerLine - 3)}...`
-      : line
+    line.length > maxCharsPerLine ? line.slice(0, maxCharsPerLine) : line
   );
-
-  if (text.split("\n").length > maxLines) {
-    const lastLine = truncated[truncated.length - 1];
-    if (lastLine && !lastLine.endsWith("...")) {
-      truncated[truncated.length - 1] = `${lastLine}...`;
-    }
-  }
-
   return truncated.join("\n");
+}
+
+/**
+ * Truncate text by line count only - no per-line character limit.
+ * Suitable for detailed views where full lines should be visible.
+ */
+export function truncateLines(text: string, maxLines: number): string {
+  const lines = text.split("\n");
+  if (lines.length <= maxLines) {
+    return text;
+  }
+  return lines.slice(0, maxLines).join("\n");
+}
+
+/**
+ * Check if text would be truncated at the given limits.
+ */
+export function isTruncated(
+  text: string,
+  maxLines: number,
+  maxCharsPerLine = 80
+): boolean {
+  const lines = text.split("\n");
+  if (lines.length > maxLines) {
+    return true;
+  }
+  return lines.some((line) => line.length > maxCharsPerLine);
+}
+
+/**
+ * Check if text would be truncated by line count only.
+ */
+export function isLineTruncated(text: string, maxLines: number): boolean {
+  return text.split("\n").length > maxLines;
 }
 
 /**

--- a/src/screens/PostDetailScreen.tsx
+++ b/src/screens/PostDetailScreen.tsx
@@ -17,7 +17,12 @@ import { QuotedPostCard } from "@/components/QuotedPostCard";
 import { usePostDetailQuery } from "@/experiments/use-post-detail-query";
 import { useListNavigation } from "@/hooks/useListNavigation";
 import { colors } from "@/lib/colors";
-import { formatCount, truncateText } from "@/lib/format";
+import {
+  formatCount,
+  isLineTruncated,
+  truncateLines,
+  truncateText,
+} from "@/lib/format";
 import {
   previewAllMedia,
   downloadAllMedia,
@@ -127,14 +132,6 @@ function formatFullTimestamp(dateString?: string): string {
   return `${dateStr} · ${timeStr}`;
 }
 
-/**
- * Check if text needs truncation
- */
-function needsTruncation(text: string, maxLines: number): boolean {
-  const lines = text.split("\n");
-  return lines.length > maxLines;
-}
-
 export function PostDetailScreen({
   client,
   tweet,
@@ -209,9 +206,9 @@ export function PostDetailScreen({
 
   const fullTimestamp = formatFullTimestamp(tweet.createdAt);
   const showTruncated =
-    !isExpanded && needsTruncation(tweet.text, MAX_TRUNCATED_LINES);
+    !isExpanded && isLineTruncated(tweet.text, MAX_TRUNCATED_LINES);
   const displayText = showTruncated
-    ? truncateText(tweet.text, MAX_TRUNCATED_LINES)
+    ? truncateLines(tweet.text, MAX_TRUNCATED_LINES)
     : tweet.text;
 
   const hasReplies = replies.length > 0;
@@ -677,11 +674,11 @@ export function PostDetailScreen({
     </box>
   );
 
-  // Truncation indicator
+  // Truncation indicator - styled like X.com's [Show more]
   const truncationIndicator = showTruncated ? (
     <box style={{ paddingLeft: 1, marginTop: 1 }}>
-      <text fg={colors.dim}>... </text>
-      <text fg={colors.primary}>[e] Expand</text>
+      <text fg={colors.primary}>[Show more]</text>
+      <text fg={colors.dim}> (e)</text>
     </box>
   ) : null;
 


### PR DESCRIPTION
## Summary
- Replace ambiguous `...` with clear blue `[Show more]` indicator in timeline (fixes #36)
- Fix detailed view per-paragraph truncation by using line-count-only limits (fixes #58)
- Refactored truncation utilities with cleaner separation of concerns

## Changes
- `truncateText()` no longer auto-appends `...` - callers show separate indicators
- New `truncateLines()` for detail view (no per-line character limits)
- New utility functions: `isTruncated()`, `isLineTruncated()`
- Timeline now displays blue `[Show more]` when text exceeds 3 lines or 80 chars/line
- Detail view shows full lines without mid-line truncation

Fixes #36 #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)