### PR TITLE
feat(ui): Add semantic color constants for action icons

### DIFF
--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -233,10 +233,10 @@ export function PostCard({
             isJustLiked
               ? colors.success // Bright green flash
               : isLikeHovered
-                ? colors.error // Red on hover (preview the liked state)
+                ? colors.liked // Red on hover (preview the liked state)
                 : isLiked
-                  ? colors.error // Red when liked
-                  : colors.muted // Muted when not liked
+                  ? colors.liked // Red when liked
+                  : colors.actionInactive // Muted when not liked
           }
         >
           {"  "}
@@ -251,10 +251,10 @@ export function PostCard({
             isJustBookmarked
               ? colors.success // Bright green flash
               : isBookmarkHovered
-                ? colors.primary // Blue on hover (preview the bookmarked state)
+                ? colors.bookmarked // Blue on hover (preview the bookmarked state)
                 : isBookmarked
-                  ? colors.primary // Blue when bookmarked
-                  : colors.muted // Muted when not bookmarked
+                  ? colors.bookmarked // Blue when bookmarked
+                  : colors.actionInactive // Muted when not bookmarked
           }
         >
           {"  "}

--- a/src/lib/colors.ts
+++ b/src/lib/colors.ts
@@ -36,6 +36,15 @@ export const colors = {
 
   /** Muted blue - used for @handles (secondary to name) */
   handle: "#6B8A9E",
+
+  /** Color for liked state (heart icon) */
+  liked: "#E0245E",
+
+  /** Color for bookmarked state (flag icon) */
+  bookmarked: "#1DA1F2",
+
+  /** Color for inactive action icons */
+  actionInactive: "#888888",
 } as const;
 
 export type ColorKey = keyof typeof colors;

--- a/src/screens/PostDetailScreen.tsx
+++ b/src/screens/PostDetailScreen.tsx
@@ -939,7 +939,7 @@ export function PostDetailScreen({
       activeColor: isJustLiked
         ? colors.success
         : isLiked
-          ? colors.error
+          ? colors.liked
           : undefined,
       isActive: isLiked || isJustLiked,
     },
@@ -949,7 +949,7 @@ export function PostDetailScreen({
       activeColor: isJustBookmarked
         ? colors.success
         : isBookmarked
-          ? colors.primary
+          ? colors.bookmarked
           : undefined,
       isActive: isBookmarked || isJustBookmarked,
     },


### PR DESCRIPTION
Add `liked`, `bookmarked`, and `actionInactive` semantic color constants
to improve theming flexibility and code clarity for like/bookmark icons.