### PR TITLE
fix: Add responsive_web_grok_annotations_enabled to TweetDetail API

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1456,6 +1456,7 @@ export class XClient {
       standardized_nudges_misinfo: true,
       tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled: true,
       rweb_video_timestamps_enabled: true,
+      responsive_web_grok_annotations_enabled: false,
     };
 
     const params = new URLSearchParams({


### PR DESCRIPTION
## Summary

X now requires the `responsive_web_grok_annotations_enabled` feature flag for TweetDetail queries. Without it, the API returns HTTP 400 with "features cannot be null" error. This fix enables replies to load properly.

## Changes

- Added missing feature flag to TweetDetail API call
- Updated x-api-debug documentation with error handling guidance and examples

## Testing

All tests pass and linting is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)