### PR TITLE
refactor: Tab navigation for main screens

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -601,20 +601,6 @@ function AppContent({ client, user }: AppProps) {
       // Overlay views (post-detail, profile) handle their own escape
     }
 
-    // Handle 'h' key for vim-style navigation (go back/left to home)
-    if (key.name === "h") {
-      if (isMainView) {
-        if (currentView === "timeline") {
-          // On timeline: show exit confirmation (same as escape)
-          showExitConfirmation();
-        } else {
-          // On bookmarks/notifications: go to timeline
-          navigate("timeline");
-        }
-        return;
-      }
-    }
-
     // Toggle footer visibility with '.' - works on all screens
     if (key.sequence === ".") {
       setShowFooter((prev) => !prev);
@@ -626,42 +612,38 @@ function AppContent({ client, user }: AppProps) {
       return;
     }
 
-    // Global navigation with number keys - works from anywhere
-    if (key.name === "1") {
-      // Clear overlay state and go to timeline
+    // Tab cycling for main screens - works from anywhere
+    if (key.name === "tab") {
+      // Clear overlay state
       setPostStack([]);
       setProfileStack([]);
       setThreadRootTweet(null);
-      navigate("timeline");
-      return;
-    }
 
-    if (key.name === "2") {
-      // Clear overlay state and go to bookmarks
-      setPostStack([]);
-      setProfileStack([]);
-      setThreadRootTweet(null);
-      navigate("bookmarks");
-      return;
-    }
-
-    if (key.name === "3") {
-      // Clear overlay state and go to notifications
-      setPostStack([]);
-      setProfileStack([]);
-      setThreadRootTweet(null);
-      navigate("notifications");
+      // Find current position and cycle
+      const currentIdx = MAIN_VIEWS.indexOf(
+        currentView as (typeof MAIN_VIEWS)[number]
+      );
+      if (currentIdx === -1) {
+        // From overlay view, go to timeline
+        navigate("timeline");
+      } else if (key.shift) {
+        // Shift+Tab: cycle backward
+        const prevIdx =
+          (currentIdx - 1 + MAIN_VIEWS.length) % MAIN_VIEWS.length;
+        const prevView = MAIN_VIEWS[prevIdx];
+        if (prevView) navigate(prevView);
+      } else {
+        // Tab: cycle forward
+        const nextIdx = (currentIdx + 1) % MAIN_VIEWS.length;
+        const nextView = MAIN_VIEWS[nextIdx];
+        if (nextView) navigate(nextView);
+      }
       return;
     }
 
     // Don't handle other keys during overlay views
     if (!isMainView) {
       return;
-    }
-
-    // Go to notifications with 'n'
-    if (key.name === "n") {
-      navigate("notifications");
     }
 
     // Go to own profile with 'p'

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -16,9 +16,7 @@ const DEFAULT_BINDINGS: Keybinding[] = [
   { key: "l", label: "like" },
   { key: "b", label: "bookmark" },
   { key: "r", label: "refresh" },
-  { key: "1", label: "home" },
-  { key: "2", label: "bookmarks" },
-  { key: "3", label: "notifs" },
+  { key: "Tab", label: "switch" },
   { key: "q", label: "quit" },
 ];
 

--- a/src/experiments/TimelineScreenExperimental.tsx
+++ b/src/experiments/TimelineScreenExperimental.tsx
@@ -155,10 +155,6 @@ export function TimelineScreenExperimental({
       case "2":
         setTab("following");
         break;
-      case "tab":
-        // Cycle between For You and Following tabs
-        setTab(tab === "for_you" ? "following" : "for_you");
-        break;
       case "r":
         refresh();
         break;

--- a/src/screens/BookmarksScreen.tsx
+++ b/src/screens/BookmarksScreen.tsx
@@ -69,7 +69,7 @@ function ScreenHeader({ folderName, inFolder }: ScreenHeaderProps) {
       </text>
       <text fg={colors.dim}>
         {" "}
-        (Tab/f folders, c new{inFolder ? ", e rename, D delete" : ""})
+        (f folders, c new{inFolder ? ", e rename, D delete" : ""})
       </text>
     </box>
   );
@@ -119,8 +119,8 @@ export function BookmarksScreen({
       refresh();
     }
 
-    // Open folder picker with 'f' or Tab
-    if (key.name === "f" || key.name === "tab") {
+    // Open folder picker with 'f'
+    if (key.name === "f") {
       onFolderPickerOpen?.();
     }
 


### PR DESCRIPTION
## Summary
Switch from number keys (1/2/3) to Tab/Shift+Tab for main screen navigation.

## Changes
- **Tab** cycles forward: Timeline → Bookmarks → Notifications
- **Shift+Tab** cycles backward
- Removed single-letter shortcuts (h, n) for main navigation
- Timeline tabs (1/2 for For You/Following) work without conflict
- BookmarksScreen folder picker now uses only 'f' key (not Tab)
- Footer updated to show 'Tab switch'

## Testing
- Tab on Timeline → goes to Bookmarks
- Tab on Bookmarks → goes to Notifications  
- Tab on Notifications → goes to Timeline
- Shift+Tab → reverse order
- 1/2 keys on Timeline → switch For You/Following tabs