### PR TITLE
fix: robust screen isolation using visible property

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -701,10 +701,10 @@ function AppContent({ client, user }: AppProps) {
       >
         {/* TanStack Query experiment: TimelineScreenExperimental */}
         <box
+          visible={currentView === "timeline"}
           style={{
-            flexGrow: currentView === "timeline" ? 1 : 0,
-            height: currentView === "timeline" ? "100%" : 0,
-            overflow: "hidden",
+            flexGrow: 1,
+            height: "100%",
           }}
         >
           <TimelineScreenExperimental
@@ -747,10 +747,10 @@ function AppContent({ client, user }: AppProps) {
 
         {/* Keep ThreadScreen mounted to preserve state, hide when not active */}
         <box
+          visible={currentView === "thread"}
           style={{
-            flexGrow: currentView === "thread" ? 1 : 0,
-            height: currentView === "thread" ? "100%" : 0,
-            overflow: "hidden",
+            flexGrow: 1,
+            height: "100%",
           }}
         >
           {threadRootTweet && (
@@ -767,10 +767,10 @@ function AppContent({ client, user }: AppProps) {
 
         {/* Keep ProfileScreen mounted to preserve state, hide when not active */}
         <box
+          visible={currentView === "profile"}
           style={{
-            flexGrow: currentView === "profile" ? 1 : 0,
-            height: currentView === "profile" ? "100%" : 0,
-            overflow: "hidden",
+            flexGrow: 1,
+            height: "100%",
           }}
         >
           {profileUsername && (
@@ -793,10 +793,10 @@ function AppContent({ client, user }: AppProps) {
 
         {/* Keep BookmarksScreen mounted to preserve state, hide when not active */}
         <box
+          visible={currentView === "bookmarks"}
           style={{
-            flexGrow: currentView === "bookmarks" ? 1 : 0,
-            height: currentView === "bookmarks" ? "100%" : 0,
-            overflow: "hidden",
+            flexGrow: 1,
+            height: "100%",
           }}
         >
           <BookmarksScreen
@@ -821,10 +821,10 @@ function AppContent({ client, user }: AppProps) {
 
         {/* Keep NotificationsScreen mounted to preserve state, hide when not active */}
         <box
+          visible={currentView === "notifications"}
           style={{
-            flexGrow: currentView === "notifications" ? 1 : 0,
-            height: currentView === "notifications" ? "100%" : 0,
-            overflow: "hidden",
+            flexGrow: 1,
+            height: "100%",
           }}
         >
           <NotificationsScreen

--- a/src/screens/BookmarksScreen.tsx
+++ b/src/screens/BookmarksScreen.tsx
@@ -69,7 +69,7 @@ function ScreenHeader({ folderName, inFolder }: ScreenHeaderProps) {
       </text>
       <text fg={colors.dim}>
         {" "}
-        (f folders, c new{inFolder ? ", e rename, D delete" : ""})
+        (f folder, n new{inFolder ? ", e rename, D delete" : ""})
       </text>
     </box>
   );
@@ -124,8 +124,8 @@ export function BookmarksScreen({
       onFolderPickerOpen?.();
     }
 
-    // Create new folder with 'c'
-    if (key.name === "c") {
+    // Create new folder with 'n'
+    if (key.name === "n") {
       onCreateFolder?.();
     }
 

--- a/src/screens/NotificationsScreen.tsx
+++ b/src/screens/NotificationsScreen.tsx
@@ -22,38 +22,6 @@ interface NotificationsScreenProps {
   onNotificationSelect?: (notification: NotificationData) => void;
 }
 
-interface ScreenHeaderProps {
-  unreadCount: number;
-  isRefetching: boolean;
-}
-
-function ScreenHeader({ unreadCount, isRefetching }: ScreenHeaderProps) {
-  return (
-    <box
-      style={{
-        flexShrink: 0,
-        paddingLeft: 1,
-        paddingRight: 1,
-        paddingBottom: 1,
-        flexDirection: "row",
-        justifyContent: "space-between",
-      }}
-    >
-      <box style={{ flexDirection: "row" }}>
-        <text fg={colors.primary}>
-          <b>Notifications</b>
-        </text>
-        {unreadCount > 0 && <text fg={colors.error}> ({unreadCount} new)</text>}
-      </box>
-      {isRefetching && (
-        <text fg={colors.muted}>
-          <i>syncing...</i>
-        </text>
-      )}
-    </box>
-  );
-}
-
 function NewNotificationsBanner({ count }: { count: number }) {
   return (
     <box
@@ -99,7 +67,6 @@ export function NotificationsScreen({
     fetchNextPage,
     refresh,
     newNotificationsCount,
-    isRefetching,
   } = useNotificationsQuery({ client });
 
   // Report counts to parent
@@ -123,7 +90,6 @@ export function NotificationsScreen({
   if (isLoading) {
     return (
       <box style={{ flexDirection: "column", height: "100%" }}>
-        {focused && <ScreenHeader unreadCount={0} isRefetching={false} />}
         <box style={{ padding: 2, flexGrow: 1 }}>
           <text fg={colors.muted}>Loading notifications...</text>
         </box>
@@ -134,9 +100,6 @@ export function NotificationsScreen({
   if (error) {
     return (
       <box style={{ flexDirection: "column", height: "100%" }}>
-        {focused && (
-          <ScreenHeader unreadCount={0} isRefetching={isRefetching} />
-        )}
         <ErrorBanner error={error} onRetry={refresh} retryDisabled={false} />
       </box>
     );
@@ -145,9 +108,6 @@ export function NotificationsScreen({
   if (notifications.length === 0) {
     return (
       <box style={{ flexDirection: "column", height: "100%" }}>
-        {focused && (
-          <ScreenHeader unreadCount={0} isRefetching={isRefetching} />
-        )}
         <box style={{ padding: 2, flexGrow: 1 }}>
           <text fg={colors.muted}>
             No notifications yet. Press r to refresh.
@@ -159,10 +119,7 @@ export function NotificationsScreen({
 
   return (
     <box style={{ flexDirection: "column", height: "100%" }}>
-      {focused && (
-        <ScreenHeader unreadCount={unreadCount} isRefetching={isRefetching} />
-      )}
-      {focused && newNotificationsCount > 0 && (
+      {newNotificationsCount > 0 && (
         <NewNotificationsBanner count={newNotificationsCount} />
       )}
       <NotificationList

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -148,6 +148,14 @@ export function ProfileScreen({
     }
   }, [isSelf, activeTab, likesFetched, isLikesLoading, fetchLikes]);
 
+  // Reset UI state when navigating to a different profile
+  useEffect(() => {
+    setIsCollapsed(false);
+    setActiveTab("tweets");
+    setMentionsMode(false);
+    setMentionIndex(0);
+  }, [username]);
+
   // Extract mentions from bio
   const bioMentions = user?.description
     ? extractMentions(user.description)

--- a/src/screens/TimelineScreen.tsx
+++ b/src/screens/TimelineScreen.tsx
@@ -112,7 +112,7 @@ export function TimelineScreen({
   if (isLoading) {
     return (
       <box style={{ flexDirection: "column", height: "100%" }}>
-        {focused && <TabBar activeTab={tab} />}
+        <TabBar activeTab={tab} />
         <box style={{ padding: 2, flexGrow: 1 }}>
           <text fg={colors.muted}>Loading timeline...</text>
         </box>
@@ -123,7 +123,7 @@ export function TimelineScreen({
   if (error) {
     return (
       <box style={{ flexDirection: "column", height: "100%" }}>
-        {focused && <TabBar activeTab={tab} />}
+        <TabBar activeTab={tab} />
         <ErrorBanner error={error} onRetry={refresh} retryDisabled={false} />
       </box>
     );
@@ -132,7 +132,7 @@ export function TimelineScreen({
   if (posts.length === 0) {
     return (
       <box style={{ flexDirection: "column", height: "100%" }}>
-        {focused && <TabBar activeTab={tab} />}
+        <TabBar activeTab={tab} />
         <box style={{ padding: 2, flexGrow: 1 }}>
           <text fg={colors.muted}>
             No posts to display. Press r to refresh.
@@ -144,7 +144,7 @@ export function TimelineScreen({
 
   return (
     <box style={{ flexDirection: "column", height: "100%" }}>
-      {focused && <TabBar activeTab={tab} />}
+      <TabBar activeTab={tab} />
       <PostList
         posts={posts}
         focused={focused}


### PR DESCRIPTION
## Summary

Fixes cross-screen header bleeding by replacing the broken height: 0 pattern with OpenTUI's native visible property.

## Root Cause

OpenTUI's scissor rect only clips when height > 0:

```typescript
const shouldPushScissor =
  this._overflow !== "visible" && this.width > 0 && this.height > 0;
```

With height: 0, overflow clipping is skipped entirely, causing content from hidden screens to bleed through.

## Changes

- **app.tsx**: Replace height: 0 toggle with `visible={currentView === "x"}` for all 5 screen containers
- **NotificationsScreen.tsx**: Remove redundant ScreenHeader (global Header shows count)
- **BookmarksScreen.tsx**: Update keybinding hints to (f folder, n new), change create folder key from c to n
- **ProfileScreen.tsx**: Add state reset when username changes
- **TimelineScreen.tsx**: Always render TabBar (parent handles visibility)

## How visible Works vs height: 0

| Property       | Rendering                    | Layout     |
| -------------- | ---------------------------- | ---------- |
| height: 0      | Still renders (no clipping!) | Calculated |
| visible: false | Properly hidden              | Skipped    |

## Testing

- TypeScript compiles without errors
- oxlint passes with 0 warnings
- All tests pass
